### PR TITLE
Use the right keyword to set env variables

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   python:
     version: 2.7.12  # this specific version is preinstalled on the CI servers and allows faster builds
-  env:
+  environment:
     PYPI_USERNAME: openfisca-bot  # set here the name of your Pypi account to automatically publish your template to Pypi
     # PYPI_PASSWORD: this value is set in CircleCI's web interface; do not set it here, it is a secret!
 


### PR DESCRIPTION
`env` [doesn't work](https://circleci.com/gh/openfisca/openfisca-france/8).
`environment` [does](https://circleci.com/gh/openfisca/openfisca-france/11).