### PR TITLE
Details install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ git clone https://github.com/openfisca/country-template.git  # download this tem
 mv country-template openfisca-$lowercase_country_name
 cd openfisca-$lowercase_country_name
 git remote remove origin
-sed -i '' '3,27d' README.md  # Remove these instructions lines
+sed -i '' '3,28d' README.md  # Remove these instructions lines
 sed -i '' "s|country_template|$lowercase_country_name|g" README.md setup.py check-version-bump.sh Makefile `find openfisca_country_template -type f`
+sed -i '' "s|country-template|$lowercase_country_name|g" README.md
 sed -i '' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py check-version-bump.sh .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md `find openfisca_country_template -type f`
 sed -i '' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
 mv openfisca_country_template openfisca_$lowercase_country_name

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Clone this Country Package on your machine:
 
 ```sh
 git clone https://github.com/openfisca/openfisca-country-template.git
-cd openfisca-france
+cd openfisca-country-template
 ```
 
 You can make sure that everything is working by running the provided tests:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is here to help you quickly bootstrap and use your own OpenFisca country package.
 
-## Bootstrapping Your Country Package
+## Bootstrapping your Country Package
 
 This set of instructions will create your own copy of this boilerplate directory and customise it to the country you want to work on:
 
@@ -42,13 +42,9 @@ These elements are described in different folders. All the modelling happens wit
 
 The files that are outside from the `openfisca_country_template` folder are used to set up the development environment.
 
-## Packaging Your Country Package for Distribution
+## Packaging your Country Package for Distribution
 
-If you wish to distribute your package via `pip install`, follow the steps given by the [Python Packaging Authority](https://python-packaging-user-guide.readthedocs.io/distributing/).
-
-If not, edit out the following sections:
-- the [Minimal Installation (pip install) section](#minimal-installation-pip-install) of the [Install instructions](#install-instructions);
-- the lines pertaining to the "minimal install" in the [section on serving the OpenFisca Web API](#serve-your-country-package-with-the-openFisca-web-api).
+Country packages are python distributions. To distribute your package via `pip install`, follow the steps given by the [Python Packaging Authority](https://python-packaging-user-guide.readthedocs.io/distributing/).
 
 ## Install Instructions for Users and Contributors
 
@@ -85,11 +81,10 @@ To set-up and create a new a virtualenv named **openfisca** running python2.7:
 pew new openfisca --python=python2.7
 ```
 
-The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately. You should see a prompt ressembling this (depending on the OS you are using) :
+The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately. You should see a prompt resembling this :
 ```sh
 Installing setuptools, pip, wheel...done.
 Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
-openfiscabash-3.2$ 
 ```
 Additional information :
 - Exit the virtualenv with `exit` (or Ctrl-D).
@@ -125,11 +120,10 @@ pip --version  # should print at least 9.0.
 Install the Country Package:
 
 ```sh
-#Example: Openfisca-France
-pip install openfisca-france
+pip install openfisca_country_template
 ```
 
-:tada: The OpenFisca Country Package is now installed and ready!
+:tada: This OpenFisca Country Package is now installed and ready!
 
 #### Next Steps
 
@@ -167,8 +161,7 @@ pip --version  # should print at least 9.0.
 Clone this Country Package on your machine:
 
 ```sh
-#Example: Openfisca-France
-git clone https://github.com/openfisca/openfisca-france.git
+git clone https://github.com/openfisca/openfisca-country-template.git
 cd openfisca-france
 ```
 
@@ -180,7 +173,7 @@ make test
 ```
 > [Learn more about tests](https://doc.openfisca.fr/coding-the-legislation/writing_yaml_tests.html)
 
-:tada: The OpenFisca Country Package is now installed and ready!
+:tada: This OpenFisca Country Package is now installed and ready!
 
 #### Next Steps
 
@@ -194,8 +187,7 @@ If you are considering building a web application, you can plug the OpenFisca We
 First, install the OpenFisca web API:
 - if you completed the minimal install, run: 
     ```sh
-    #Example: Openfisca-France
-    pip install openfisca-france[api]
+    pip install openfisca-country-template[api]
     ```
 - if you completed the advanced install, run:
     ```sh
@@ -214,4 +206,4 @@ You can make sure that your instance of the API is working by requesting:
 curl "http://localhost:2000/api/1/swagger"
 ```
 
-:tada: The OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)
+:tada: This OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/
 To install pew, launch a terminal on your computer and follow these instructions:
 
 ```sh
-python -V # You should have python 2.7.9 or better installed on your computer.
+python --version # You should have python 2.7.9 or better installed on your computer.
 # If not, visit http://www.python.org to install it and install pip as well.
 ```
 
@@ -81,12 +81,12 @@ To set-up and create a new a virtualenv named **openfisca** running python2.7:
 pew new openfisca --python=python2.7
 ```
 
-The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately. You should see a prompt resembling this :
+The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately. You should see a prompt resembling this:
 ```sh
 Installing setuptools, pip, wheel...done.
 Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
 ```
-Additional information :
+Additional information:
 - Exit the virtualenv with `exit` (or Ctrl-D).
 - Re-enter with `pew workon openfisca`.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The files that are outside from the `openfisca_country_template` folder are used
 
 ## Packaging your Country Package for Distribution
 
-Country packages are python distributions. To distribute your package via `pip install`, follow the steps given by the [Python Packaging Authority](https://python-packaging-user-guide.readthedocs.io/distributing/).
+Country packages are python distributions. To distribute your package via `pip`, follow the steps given by the [Python Packaging Authority](https://python-packaging-user-guide.readthedocs.io/tutorials/distributing-packages/#packaging-your-project).
 
 ## Install Instructions for Users and Contributors
 
@@ -163,6 +163,7 @@ Clone this Country Package on your machine:
 ```sh
 git clone https://github.com/openfisca/openfisca-country-template.git
 cd openfisca-country-template
+pip install -e '.'
 ```
 
 You can make sure that everything is working by running the provided tests:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If not, edit out the following sections:
 
 ## Install Instructions for Users and Contributors
 
-This package requires [Python 2.7](https://www.python.org/downloads/).
+This package requires [Python 2.7](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/stable/installing/) .
 
 Supported platforms:
 - GNU/Linux distributions (in particular Debian and Ubuntu);
@@ -71,13 +71,13 @@ We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/
 To install pew, launch a terminal on your computer and follow these instructions:
 
 ```sh
-Python -V # You should have python 2.7.9 or better installed on your computer.
-# If not, visit http://www.python.org to install it.
+python -V # You should have python 2.7.9 or better installed on your computer.
+# If not, visit http://www.python.org to install it and install pip as well.
 ```
 
 ```sh
 pip install --upgrade pip
-pip install pew  # answer "Y" to the question about modifying your shell config file.
+pip install pew  # if asked, answer "Y" to the question about modifying your shell config file.
 ```
 To set-up and create a new a virtualenv named **openfisca** running python2.7:
 
@@ -85,9 +85,19 @@ To set-up and create a new a virtualenv named **openfisca** running python2.7:
 pew new openfisca --python=python2.7
 ```
 
-The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately.
+The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately. You should see a prompt ressembling this (depending on the OS you are using) :
+```sh
+Installing setuptools, pip, wheel...done.
+Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
+openfiscabash-3.2$ 
+```
+Additional information :
 - Exit the virtualenv with `exit` (or Ctrl-D).
 - Re-enter with `pew workon openfisca`.
+
+:tada: You are now ready to install this OpenFisca Country Package!
+
+We offer 2 install procedures. Pick procedure A or B below depending on how you plan to use this Country Package. 
 
 ### A. Minimal Installation (Pip Install)
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Clone this Country Package on your machine:
 ```sh
 git clone https://github.com/openfisca/openfisca-country-template.git
 cd openfisca-country-template
-pip install -e '.'
+pip install -e .
 ```
 
 You can make sure that everything is working by running the provided tests:
@@ -191,7 +191,7 @@ First, install the OpenFisca web API:
     ```sh
     pip install openfisca-country-template[api]
     ```
-- if you completed the advanced install, run:
+- if you completed the advanced install, run the following command in your openfisca-country-template repository:
     ```sh
     pip install -e '.[api]'
     ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The virtualenv you just created will be automatically activated. This means you 
 - Exit the virtualenv with `exit` (or Ctrl-D).
 - Re-enter with `pew workon openfisca`.
 
-### Minimal Installation (Pip Install)
+### A. Minimal Installation (Pip Install)
 
 Follow this installation if you wish to:
 - run calculations on a large population;
@@ -124,7 +124,7 @@ Depending on what you want to do with OpenFisca, you may want to install yet oth
 - To plot simulation results, try [matplotlib](http://matplotlib.org/).
 - To manage data, check out [pandas](http://pandas.pydata.org/).
 
-### Advanced Installation (Git Clone)
+### B. Advanced Installation (Git Clone)
 
 Follow this tutorial if you wish to:
 - create or change this Country Package's legislation;

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If not, edit out the following sections:
 
 ## Install Instructions for Users and Contributors
 
-This package requires Python 2.7.
+This package requires [Python 2.7](https://www.python.org/downloads/).
 
 Supported platforms:
 - GNU/Linux distributions (in particular Debian and Ubuntu);
@@ -69,6 +69,11 @@ We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/
 - A virtualenv manager, such as [pew](https://github.com/berdario/pew), lets you easily create, remove and toggle between several virtualenvs.
 
 To install pew, launch a terminal on your computer and follow these instructions:
+
+```sh
+Python -V # You should have python 2.7 or better installed on your computer.
+# If not, visit http://www.python.org to install it.
+```
 
 ```sh
 pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/
 To install pew, launch a terminal on your computer and follow these instructions:
 
 ```sh
-Python -V # You should have python 2.7 or better installed on your computer.
+Python -V # You should have python 2.7.9 or better installed on your computer.
 # If not, visit http://www.python.org to install it.
 ```
 
@@ -118,6 +118,8 @@ Install the Country Package:
 #Example: Openfisca-France
 pip install openfisca-france
 ```
+
+:tada: The OpenFisca Country Package is now installed and ready!
 
 #### Next Steps
 
@@ -168,7 +170,7 @@ make test
 ```
 > [Learn more about tests](https://doc.openfisca.fr/coding-the-legislation/writing_yaml_tests.html)
 
-The OpenFisca Country Package is now installed and ready!
+:tada: The OpenFisca Country Package is now installed and ready!
 
 #### Next Steps
 
@@ -202,4 +204,4 @@ You can make sure that your instance of the API is working by requesting:
 curl "http://localhost:2000/api/1/swagger"
 ```
 
-To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)
+:tada: The OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is here to help you quickly bootstrap and use your own OpenFisca country package.
 
-## Bootstrapping a country package
+## Bootstrapping Your Country Package
 
 This set of instructions will create your own copy of this boilerplate directory and customise it to the country you want to work on:
 
@@ -25,7 +25,7 @@ sed -i '' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" set
 mv openfisca_country_template openfisca_$lowercase_country_name
 ```
 
-## Writing the legislation
+## Writing the Legislation
 
 The country whose law is modelled here has a very simple tax and benefit system.
 
@@ -42,46 +42,159 @@ These elements are described in different folders. All the modelling happens wit
 
 The files that are outside from the `openfisca_country_template` folder are used to set up the development environment.
 
+## Packaging Your Country Package for Distribution
 
-## Installing
+If you wish to distribute your package via `pip install`, follow the steps given by the [Python Packaging Authority](https://python-packaging-user-guide.readthedocs.io/distributing/).
 
-> We recommend that you [use a virtualenv](https://doc.openfisca.fr/for_developers.html#create-a-virtualenv) to install OpenFisca. If you don't, you may need to add `--user` at the end of all commands starting by `pip`.
+If not, edit out the following sections:
+- the [Minimal Installation (pip install) section](#minimal-installation-pip-install) of the [Install instructions](#install-instructions);
+- the lines pertaining to the "minimal install" in the [section on serving the OpenFisca Web API](#serve-your-country-package-with-the-openFisca-web-api).
 
-To install your country package, run:
+## Install Instructions for Users and Contributors
 
+This package requires Python 2.7.
+
+Supported platforms:
+- GNU/Linux distributions (in particular Debian and Ubuntu);
+- Mac OS X;
+- Microsoft Windows (we recommend using [ConEmu](https://conemu.github.io/) instead of the default console).
+
+Other OS should work if they can execute Python and NumPy.
+
+### Setting-up a Virtual Environment with Pew
+
+We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/) (abbreviated as "virtualenv") with a virtualenv manager such as [pew](https://github.com/berdario/pew).
+
+- A [virtualenv](https://virtualenv.pypa.io/en/stable/) is a project specific environment created to suit the needs of the project you are working on.
+- A virtualenv manager, such as [pew](https://github.com/berdario/pew), lets you easily create, remove and toggle between several virtualenvs.
+
+To install pew, launch a terminal on your computer and follow these instructions:
+
+```sh
+pip install --upgrade pip
+pip install pew  # answer "Y" to the question about modifying your shell config file.
 ```
-pip install -e ".[test]"
+To set-up and create a new a virtualenv named **openfisca** running python2.7:
+
+```sh
+pew new openfisca --python=python2.7
+```
+
+The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately.
+- Exit the virtualenv with `exit` (or Ctrl-D).
+- Re-enter with `pew workon openfisca`.
+
+### Minimal Installation (Pip Install)
+
+Follow this installation if you wish to:
+- run calculations on a large population;
+- create tax & benefits simulations;
+- write an extension to this legislation (e.g. city specific tax & benefits);
+- serve your Country Package with the OpenFisca Web API.
+
+For more advanced uses, head to the [Advanced Installation](#advanced-installation-git-clone).
+
+#### Install this Country Package with Pip Install
+
+Inside your virtualenv, check the prerequisites:
+
+```sh
+python --version  # should print "Python 2.7.xx".
+#if not, make sure you pass the python version as an argument when creating your virtualenv
+```
+
+```sh
+pip --version  # should print at least 9.0.
+#if not, run "pip install --upgrade pip"
+```
+Install the Country Package:
+
+```sh
+#Example: Openfisca-France
+pip install openfisca-france
+```
+
+#### Next Steps
+
+- To learn how to use OpenFisca, follow our [tutorials](https://doc.openfisca.fr/getting-started.html).
+- To serve this Country Package, serve the [OpenFisca web API](#serve-your-country-package-with-the-openFisca-web-api).
+
+Depending on what you want to do with OpenFisca, you may want to install yet other packages in your virtualenv:
+- To install extensions or write on top of this Country Package, head to the [Extensions documentation](https://doc.openfisca.fr/contribute/extensions.html).
+- To plot simulation results, try [matplotlib](http://matplotlib.org/).
+- To manage data, check out [pandas](http://pandas.pydata.org/).
+
+### Advanced Installation (Git Clone)
+
+Follow this tutorial if you wish to:
+- create or change this Country Package's legislation;
+- contribute to the source code.
+
+#### Clone this Country Package with Git
+
+First of all, make sure [Git](https://www.git-scm.com/) is installed on your machine.
+
+Set your working directory to the location where you want this OpenFisca Country Package cloned.
+
+Inside your virtualenv, check the prerequisites:
+
+```sh
+python --version  # should print "Python 2.7.xx".
+#if not, make sure you pass the python version as an argument when creating your virtualenv
+```
+
+```sh
+pip --version  # should print at least 9.0.
+#if not, run "pip install --upgrade pip"
+```
+Clone this Country Package on your machine:
+
+```sh
+#Example: Openfisca-France
+git clone https://github.com/openfisca/openfisca-france.git
+cd openfisca-france
 ```
 
 You can make sure that everything is working by running the provided tests:
 
 ```sh
+pip install -e ".[test]"
 make test
 ```
-
 > [Learn more about tests](https://doc.openfisca.fr/coding-the-legislation/writing_yaml_tests.html)
 
-Your country package is now installed and ready!
+The OpenFisca Country Package is now installed and ready!
 
+#### Next Steps
 
-## Serving your country package with the OpenFisca web API
+- To write new legislation, read the [Coding the legislation](https://doc.openfisca.fr/coding-the-legislation/index.html) section to know how to write legislation.
+- To contribute to the code, read our [Contribution Guidebook](https://doc.openfisca.fr/contribute/index.html).
 
-If you are considering building a web application, you can plug the OpenFisca web api to your country package.
+## Serve this Country Package with the OpenFisca Web API
+
+If you are considering building a web application, you can plug the OpenFisca Web API to your Country Package.
 
 First, install the OpenFisca web API:
-```sh
-pip install -e '.[api]'
-```
+- if you completed the minimal install, run: 
+    ```sh
+    #Example: Openfisca-France
+    pip install openfisca-france[api]
+    ```
+- if you completed the advanced install, run:
+    ```sh
+    pip install -e '.[api]'
+    ```
 
-Then run:
+Then serve the Openfisca Web API locally:
+
 ```sh
 openfisca-serve --port 2000
 ```
 
-You can make sure that the api is working by requesting:
+You can make sure that your instance of the API is working by requesting:
 
 ```sh
-curl "http://localhost:2000/api/2/formula/income_tax?salary=4000"
+curl "http://localhost:2000/api/1/swagger"
 ```
 
-> [Learn more about the API](https://doc.openfisca.fr/openfisca-web-api/index.html)
+To learn more, go to the [OpenFisca Web API documentation](https://doc.openfisca.fr/openfisca-web-api/index.html)


### PR DESCRIPTION
Connected to openfisca/openfisca-doc#77

This PR adds install instructions that are Country Package agnostic.
The install instruction where discussed in [Give users an actionnable install procedure #774](https://github.com/openfisca/openfisca-france/pull/774), an OpenFisca-France PR
* Minor change.
* Impacted periods: all
* Impacted areas: `README.md`
* Details:
  - New section on packaging the Country Package
  - New section on Installation

- - - -

These changes :

- Change non-functional parts of this repository (for instance editing the README)
