### PR TITLE
Check version number change before deployment 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,4 @@ deployment:
   master:
     branch: master
     commands:
-      - git tag `python setup.py --version`
-      - git push --tags  # update the repository version
-      - python setup.py bdist_wheel  # build this package in the dist directory
-      - twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish
+      - ./deploy-if-version-bump.sh

--- a/deploy-if-version-bump.sh
+++ b/deploy-if-version-bump.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+if ! git rev-parse `python setup.py --version` 2>/dev/null ; then
+    git tag `python setup.py --version`
+    git push --tags  # update the repository version
+    python setup.py bdist_wheel  # build this package in the dist directory
+    twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish
+else
+    echo "No deployment - Only non-functional elements were modified in this change"
+fi


### PR DESCRIPTION
Connected to openfisca/openfisca-core#513

This PR is the implementation in the Country Template Package of the procedure to check version number before attempting to deploy discussed in  [Check version number change before deployment](https://github.com/openfisca/openfisca-core/pull/547).

#### Technical changes
When there is a new commit on the master branch, if the version number has not been changed, the deployment will not be triggered.
