### PR TITLE
Add an Enum example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.2.4 - [#16](https://github.com/openfisca/country-template/pull/16)
+
+* Tax and benefit system evolution
+* Details
+  - Introduce `housing_occupancy_status`
+  - Take the housing occupancy status into account in the housing tax
+
 # 1.2.3 - [#9](https://github.com/openfisca/country-template/pull/9)
 
 * Technical improvement: adapt to version `15.0.0` of Openfisca-Core

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -24,3 +24,20 @@ class rent(Variable):
     entity = Household
     definition_period = MONTH
     label = u"Rent paid by the household"
+
+
+#  Possible values for the housing_occupancy_status variable, defined further down
+HOUSING_OCCUPANCY_STATUS = Enum([
+    u'Tenant',
+    u'Owner',
+    u'Free logder',
+    u'Homeless'])
+
+
+class housing_occupancy_status(Variable):
+    column = EnumCol(
+        enum = HOUSING_OCCUPANCY_STATUS
+        )
+    entity = Household
+    definition_period = MONTH
+    label = u"Legal housing situation of the household concerning their main residence"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='1.2.3',
+    version='1.2.4',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',


### PR DESCRIPTION
Connected to openfisca/legislation-explorer#95

* Tax and benefit system evolution
* Details
  - Introduce `housing_occupancy_status`
  - Take the housing occupancy status into account in the housing tax