### PR TITLE
Add python 3 enum handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 2.0.0 - [#24](https://github.com/openfisca/country-template/pull/24)
 
-* Technical change
+#### breaking change
+
 * Details:
+  - Upgrade to Core v21
   - Introduce the use of a string identifier to reference enum item.
   - When setting an Enums (e.g. housing_occupancy_status), set the relevant string identifier (e.g. `free_lodger`). Indexes (e.g.`2`) and phrases (e.g. `Free Lodgers`) cannot be used anymore.
   - The default value is indicated for each enum variable instead of being implicitly the first item of the enum.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Now:
 "households": {
     "_": {
         "parent": ["Bill"]
-        housing_occupancy_status: "free_lodger"
+        "housing_occupancy_status": "free_lodger"
     }
 }
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## 2.0.0 - [#24](https://github.com/openfisca/country-template/pull/24)
+
+* Technical change
+* Details:
+  - Introduce the use of a string identifier to reference enum item.
+  - When setting an Enums (e.g. housing_occupancy_status), set the relevant string identifier (e.g. `free_lodger`). Indexes (e.g.`2`) and phrases (e.g. `Free Lodgers`) cannot be used anymore.
+  - The default value is indicated for each enum variable instead of being implicitly the first item of the enum.
+
+#### Web API request/response
+
+Before:
+
+```
+"persons": {
+    "Bill": {}
+},
+"households": {
+    "_": {
+        "parent": ["Bill"]
+        "housing_occupancy_status": "Free Lodger"
+    }
+}
+```
+Now:
+
+```
+"persons": {
+    "Bill": {}
+},
+"households": {
+    "_": {
+        "parent": ["Bill"]
+        housing_occupancy_status: "free_lodger"
+    }
+}
+```
+
+#### YAML testing
+Before:
+
+```
+name: Household living in a 40 sq.meters accomodation while free_lodgers
+  period: 2017
+  input_variables:
+    accomodation_size:
+      2017-01: 40
+    housing_occupancy_status:
+      2017-01: 2
+  output_variables:
+    housing_tax: 0
+```
+Now:
+
+```
+name: Household living in a 40 sq.meters accomodation while free_lodgers
+  period: 2017
+  input_variables:
+    accomodation_size:
+      2017-01: 40
+    housing_occupancy_status:
+      2017-01: free_lodger
+  output_variables:
+    housing_tax: 0
+```
+
+#### Python API
+
+When calculating an enum variable in Python, the output will be an array of enum items.
+> Each enum item has:
+> - a `name` property that contains its key (e.g. `tenant`)
+> - a `value` property that contains its description (e.g. `"Tenant or lodger who pays a monthly rent"`)
+
 ## 1.4.0 - [#26](https://github.com/openfisca/country-template/pull/26)
 
 * Technical improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 * Details:
   - Upgrade to Core v21
-  - Introduce the use of a string identifier to reference enum item.
-  - When setting an Enums (e.g. housing_occupancy_status), set the relevant string identifier (e.g. `free_lodger`). Indexes (e.g.`2`) and phrases (e.g. `Free Lodgers`) cannot be used anymore.
-  - The default value is indicated for each enum variable instead of being implicitly the first item of the enum.
+  - Introduce the use of a string identifier to reference Enum items.
+  - When setting an Enum (e.g. housing_occupancy_status), set the relevant string identifier (e.g. `free_lodger`). Indexes (e.g.`2`) and phrases (e.g. `Free Lodgers`) cannot be used anymore.
+  - The default value is indicated for each Enum variable instead of being implicitly the first item of the enum.
 
 #### Web API request/response
 
@@ -43,7 +43,7 @@ Now:
 Before:
 
 ```
-name: Household living in a 40 sq.meters accomodation while free_lodgers
+name: Household living in a 40 sq.meters accomodation while being free lodgers
   period: 2017
   input_variables:
     accomodation_size:
@@ -56,7 +56,7 @@ name: Household living in a 40 sq.meters accomodation while free_lodgers
 Now:
 
 ```
-name: Household living in a 40 sq.meters accomodation while free_lodgers
+name: Household living in a 40 sq.meters accomodation while being free lodgers
   period: 2017
   input_variables:
     accomodation_size:
@@ -69,8 +69,9 @@ name: Household living in a 40 sq.meters accomodation while free_lodgers
 
 #### Python API
 
-When calculating an enum variable in Python, the output will be an array of enum items.
-> Each enum item has:
+When calculating an enum variable in Python, the output will be an array of Enum items.
+
+> Each Enum item has:
 > - a `name` property that contains its key (e.g. `tenant`)
 > - a `value` property that contains its description (e.g. `"Tenant or lodger who pays a monthly rent"`)
 

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -28,3 +28,5 @@
       2017-01: 100
   output_variables:
     housing_tax: 1000
+    housing_occupancy_status:
+      2017-01: tenant

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -1,7 +1,7 @@
 # Test files describe situations and their expected outcomes
 # We can run this test on our command line using `openfisca-run-test housing_tax.yaml`
 
-- name: Household living in a 40 sq.meters accomodation while tenants
+- name: Tenantd living in a 40 sq.meters accomodation
   period: 2017
   input_variables:
     accomodation_size:
@@ -11,7 +11,7 @@
   output_variables:
     housing_tax: 400
 
-- name: Household living in a 40 sq.meters accomodation while free_lodgers
+- name: Free_lodgers living in a 40 sq.meters accomodation
   period: 2017
   input_variables:
     accomodation_size:

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -1,13 +1,25 @@
 # Test files describe situations and their expected outcomes
 # We can run this test on our command line using `openfisca-run-test housing_tax.yaml`
 
-- name: Household living in a 40 sq.meters accomodation
+- name: Household living in a 40 sq.meters accomodation while tenants
   period: 2017
   input_variables:
     accomodation_size:
       2017-01: 40
+    housing_occupancy_status:
+      2017-01: tenant
   output_variables:
     housing_tax: 400
+
+- name: Household living in a 40 sq.meters accomodation while free_lodgers
+  period: 2017
+  input_variables:
+    accomodation_size:
+      2017-01: 40
+    housing_occupancy_status:
+      2017-01: free_lodger
+  output_variables:
+    housing_tax: 0
 
 - name: Household living in a 100 sq.meters accomodation
   period: 2017

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -1,7 +1,7 @@
 # Test files describe situations and their expected outcomes
 # We can run this test on our command line using `openfisca-run-test housing_tax.yaml`
 
-- name: Tenantd living in a 40 sq.meters accomodation
+- name: Tenant living in a 40 sq.meters accomodation
   period: 2017
   input_variables:
     accomodation_size:

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -8,6 +8,7 @@
 from openfisca_core.model_api import *
 # Import the entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import *
+from enum import Enum
 
 
 # This variable is a pure input: it doesn't have a formula
@@ -27,16 +28,17 @@ class rent(Variable):
 
 
 #  Possible values for the housing_occupancy_status variable, defined further down
-HOUSING_OCCUPANCY_STATUS = Enum([
-    u'Tenant',
-    u'Owner',
-    u'Free logder',
-    u'Homeless'])
+class HousingOccupancyStatus(Enum):
+    tenant = u'Tenant'
+    owner = u'Owner'
+    free_lodger = u'Free logder'
+    homeless = u'Homeless'
 
 
 class housing_occupancy_status(Variable):
     value_type = Enum
-    possible_values = HOUSING_OCCUPANCY_STATUS
+    possible_values = HousingOccupancyStatus
+    default = HousingOccupancyStatus.tenant
     entity = Household
     definition_period = MONTH
     label = u"Legal housing situation of the household concerning their main residence"

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -38,7 +38,7 @@ class HousingOccupancyStatus(Enum):
 class housing_occupancy_status(Variable):
     value_type = Enum
     possible_values = HousingOccupancyStatus
-    default = HousingOccupancyStatus.tenant
+    default_value = HousingOccupancyStatus.tenant
     entity = Household
     definition_period = MONTH
     label = u"Legal housing situation of the household concerning their main residence"

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -54,7 +54,7 @@ class housing_tax(Variable):
         january = period.first_month
         accommodation_size = household('accomodation_size', january)
 
-        # `housing_occupancy_status` is an Enum. To access an enum element, we use the [] notation.
+        # `housing_occupancy_status` is an Enum. To access an enum element, we use the . notation.
         # Note than HousingOccupancyStatus has been imported on the beginning of this file.
         occupancy_status = household('housing_occupancy_status', january)
         tenant = (occupancy_status == HousingOccupancyStatus.tenant)

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -9,7 +9,7 @@ from openfisca_core.model_api import *
 # Import the entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import *
 
-from housing import HOUSING_OCCUPANCY_STATUS
+from housing import HousingOccupancyStatus
 
 
 class income_tax(Variable):
@@ -55,10 +55,10 @@ class housing_tax(Variable):
         accommodation_size = household('accomodation_size', january)
 
         # `housing_occupancy_status` is an Enum. To access an enum element, we use the [] notation.
-        # Note than HOUSING_OCCUPANCY_STATUS has been imported on the beginning of this file.
+        # Note than HousingOccupancyStatus has been imported on the beginning of this file.
         occupancy_status = household('housing_occupancy_status', january)
-        tenant = (occupancy_status == HOUSING_OCCUPANCY_STATUS['Tenant'])
-        owner = (occupancy_status == HOUSING_OCCUPANCY_STATUS['Owner'])
+        tenant = (occupancy_status == HousingOccupancyStatus.tenant)
+        owner = (occupancy_status == HousingOccupancyStatus.owner)
 
         # The tax is applied only if the household owns or rents its main residency
         return (owner + tenant) * accommodation_size * 10

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setup(
     url='https://github.com/openfisca/openfisca-country-template',
     include_package_data = True,  # Will read MANIFEST.in
     install_requires=[
-        'OpenFisca-Core >= 20.0.0, < 21.0',
+        'OpenFisca-Core >= 21.0.0, < 22.0',
         ],
     extras_require = {
         'api': [
             'OpenFisca-Web-API >= 4.0.0, < 7.0',
             ],
         'test': [
-            'flake8',
+            'flake8 >= 3.4.0, < 3.5.0',
             'flake8-print',
             'nose',
             ]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='1.4.0',
+    version='2.0.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',


### PR DESCRIPTION
Connected to openfisca/openfisca-france#831

* Technical improvement. 
* Impacted areas: `openfisca_country_template/variables/housing.py`, openfisca_country_template/variables/taxes.py
* Details:
  - EnumCols (e.g. housing_occupancy_status) , now reference an Enum Class (e.g. HousingOccupancyStatus) that has a name & description for each item and an explicit default value.

These changes:

- Impact the OpenFisca-Country-Template public API (for instance renaming or removing a variable)
