### PR TITLE
Improve spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 2.1.1 - [#34](https://github.com/openfisca/country-template/pull/34)
+
+* Minor change.
+* Impacted areas: no functional impact.
+* Details:
+  - Improved spelling
+
 ## 2.1.0 - [#29](https://github.com/openfisca/country-template/pull/29) [#30](https://github.com/openfisca/country-template/pull/30)
 
 * Tax and benefit system evolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 2.1.0 - [#29](https://github.com/openfisca/country-template/pull/29) [#30](https://github.com/openfisca/country-template/pull/30)
 
 * Tax and benefit system evolution
-* Impacted areas: 
+* Impacted areas:
   - Parameters `general`
   - Variables `benefits`
 * Details:
-  - Add a parameter and a variable with non ascii characters 
+  - Add a parameter and a variable with non ascii characters
     - Introduce `age_of_retirement` parameter
     - Introduce `pension` variable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-### 2.1.1 - [#34](https://github.com/openfisca/country-template/pull/34)
+# 3.0.0 - [#34](https://github.com/openfisca/country-template/pull/34)
+
+#### Breaking change
+
+* Tax and benefit system evolution.
+* Impacted periods: all.
+* Impacted areas: `variables/housing`
+* Details:
+  - Fix spelling by renaming `accomodation_size` variable to `accommodation_size`
+
+#### Other changes
 
 * Minor change.
 * Impacted areas: no functional impact.
@@ -63,10 +73,10 @@ Now:
 Before:
 
 ```
-name: Household living in a 40 sq. metres accomodation while being free lodgers
+name: Household living in a 40 sq. metres accommodation while being free lodgers
   period: 2017
   input_variables:
-    accomodation_size:
+    accommodation_size:
       2017-01: 40
     housing_occupancy_status:
       2017-01: 2
@@ -76,10 +86,10 @@ name: Household living in a 40 sq. metres accomodation while being free lodgers
 Now:
 
 ```
-name: Household living in a 40 sq. metres accomodation while being free lodgers
+name: Household living in a 40 sq. metres accommodation while being free lodgers
   period: 2017
   input_variables:
-    accomodation_size:
+    accommodation_size:
       2017-01: 40
     housing_occupancy_status:
       2017-01: free_lodger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Now:
 Before:
 
 ```
-name: Household living in a 40 sq.meters accomodation while being free lodgers
+name: Household living in a 40 sq. metres accomodation while being free lodgers
   period: 2017
   input_variables:
     accomodation_size:
@@ -69,7 +69,7 @@ name: Household living in a 40 sq.meters accomodation while being free lodgers
 Now:
 
 ```
-name: Household living in a 40 sq.meters accomodation while being free lodgers
+name: Household living in a 40 sq. metres accomodation while being free lodgers
   period: 2017
   input_variables:
     accomodation_size:

--- a/openfisca_country_template/parameters/general/age_of_retirement.yaml
+++ b/openfisca_country_template/parameters/general/age_of_retirement.yaml
@@ -1,5 +1,5 @@
 # A parameter can contain utf-8 characters.
-description: Age of retirement (in years). Âge de la retraite (en années).
+description: Age of retirement (in years). In French âge de la retraite (en années).
 reference: https://fr.wikipedia.org/wiki/Retraite_(économie)
 values:
   2017-01-01:

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -1,7 +1,7 @@
 # Test files describe situations and their expected outcomes
 # We can run this test on our command line using `openfisca-run-test housing_tax.yaml`
 
-- name: Tenant living in a 40 sq.meters accomodation
+- name: Tenant living in a 40 sq. metres accomodation
   period: 2017
   input_variables:
     accomodation_size:
@@ -11,7 +11,7 @@
   output_variables:
     housing_tax: 400
 
-- name: Free_lodgers living in a 40 sq.meters accomodation
+- name: Free_lodgers living in a 40 sq. metres accomodation
   period: 2017
   input_variables:
     accomodation_size:
@@ -21,7 +21,7 @@
   output_variables:
     housing_tax: 0
 
-- name: Household living in a 100 sq.meters accomodation
+- name: Household living in a 100 sq. metres accomodation
   period: 2017
   input_variables:
     accomodation_size:

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -11,7 +11,7 @@
   output_variables:
     housing_tax: 400
 
-- name: Free_lodgers living in a 40 sq. metres accommodation
+- name: Free lodgers living in a 40 sq. metres accommodation
   period: 2017
   input_variables:
     accommodation_size:

--- a/openfisca_country_template/tests/housing_tax.yaml
+++ b/openfisca_country_template/tests/housing_tax.yaml
@@ -1,30 +1,30 @@
 # Test files describe situations and their expected outcomes
 # We can run this test on our command line using `openfisca-run-test housing_tax.yaml`
 
-- name: Tenant living in a 40 sq. metres accomodation
+- name: Tenant living in a 40 sq. metres accommodation
   period: 2017
   input_variables:
-    accomodation_size:
+    accommodation_size:
       2017-01: 40
     housing_occupancy_status:
       2017-01: tenant
   output_variables:
     housing_tax: 400
 
-- name: Free_lodgers living in a 40 sq. metres accomodation
+- name: Free_lodgers living in a 40 sq. metres accommodation
   period: 2017
   input_variables:
-    accomodation_size:
+    accommodation_size:
       2017-01: 40
     housing_occupancy_status:
       2017-01: free_lodger
   output_variables:
     housing_tax: 0
 
-- name: Household living in a 100 sq. metres accomodation
+- name: Household living in a 100 sq. metres accommodation
   period: 2017
   input_variables:
-    accomodation_size:
+    accommodation_size:
       2017-01: 100
   output_variables:
     housing_tax: 1000

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -48,13 +48,14 @@ class pension(Variable):
     value_type = float
     entity = Person
     definition_period = MONTH
-    label = "Pension for the elderly. Pension attribuée aux personnes âgées."
+    label = "Pension for the elderly. Pension attribuée aux personnes âgées. تقاعد."
     reference = [u"https://fr.wikipedia.org/wiki/Retraite_(économie)", u"https://ar.wikipedia.org/wiki/تقاعد"]
 
     def formula(person, period):
         '''
-        A person's pension depends on its birth date.
-        In french : La pension d'une personne est attribuée d'après la date de naissance.
+        A person's pension depends on their birth date.
+        In French: retraite selon l'âge.
+        In Arabic: تقاعد.
         '''
         age_condition = person('age', period) >= parameters(period).general.age_of_retirement
         return age_condition

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -34,7 +34,7 @@ class housing_allowance(Variable):
     value_type = float
     entity = Household
     definition_period = MONTH
-    label = "Housing allowange"
+    label = "Housing allowance"
     reference = "https://law.gov.example/housing_allowance"  # Always use the most official source
     end = '2016-11-30'  # This allowance was removed on the 1st of Dec 2016. Calculating it before this date will always return the variable default value, 0.
 

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -15,7 +15,7 @@ class accomodation_size(Variable):
     value_type = float
     entity = Household
     definition_period = MONTH
-    label = u"Size of the accomodation, in square metters"
+    label = u"Size of the accomodation, in square metres"
 
 
 # This variable is a pure input: it doesn't have a formula
@@ -31,7 +31,7 @@ class HousingOccupancyStatus(Enum):
     __order__ = "owner tenant free_lodger homeless"
     owner = u'Owner'
     tenant = u'Tenant'
-    free_lodger = u'Free logder'
+    free_lodger = u'Free lodger'
     homeless = u'Homeless'
 
 

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -15,7 +15,7 @@ class accomodation_size(Variable):
     value_type = float
     entity = Household
     definition_period = MONTH
-    label = u"Size of the accomodation, in square metres"
+    label = u"Size of the accommodation, in square metres"
 
 
 # This variable is a pure input: it doesn't have a formula

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -11,7 +11,7 @@ from openfisca_country_template.entities import *
 
 
 # This variable is a pure input: it doesn't have a formula
-class accomodation_size(Variable):
+class accommodation_size(Variable):
     value_type = float
     entity = Household
     definition_period = MONTH

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -55,7 +55,7 @@ class housing_tax(Variable):
         # `housing_occupancy_status` is an Enum variable
         occupancy_status = household('housing_occupancy_status', january)
         HousingOccupancyStatus = occupancy_status.possible_values  # Get the enum associated with the variable
-        # To access an enum element, we use the . notation.
+        # To access an enum element, we use the `.` notation.
         tenant = (occupancy_status == HousingOccupancyStatus.tenant)
         owner = (occupancy_status == HousingOccupancyStatus.owner)
 

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -42,7 +42,7 @@ class housing_tax(Variable):
     value_type = float
     entity = Household
     definition_period = YEAR  # This housing tax is defined for a year.
-    label = u"Tax paid by each household proportionnally to the size of its accommodation"
+    label = u"Tax paid by each household proportionally to the size of its accommodation"
     reference = "https://law.gov.example/housing_tax"  # Always use the most official source
 
     def formula(household, period, parameters):

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -46,11 +46,11 @@ class housing_tax(Variable):
     reference = "https://law.gov.example/housing_tax"  # Always use the most official source
 
     def formula(household, period, parameters):
-        # The housing tax is defined for a year, but depends on the `accomodation_size` and `housing_occupancy_status` on the first month of the year.
+        # The housing tax is defined for a year, but depends on the `accommodation_size` and `housing_occupancy_status` on the first month of the year.
         # Here period is a year. We can get the first month of a year with the following shortcut.
         # To build different periods, see http://openfisca.org/doc/coding-the-legislation/35_periods.html#calculating-dependencies-for-a-specific-period
         january = period.first_month
-        accommodation_size = household('accomodation_size', january)
+        accommodation_size = household('accommodation_size', january)
 
         # `housing_occupancy_status` is an Enum variable
         occupancy_status = household('housing_occupancy_status', january)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='2.1.1',
+    version='3.0.0',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='2.1.0',
+    version='2.1.1',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',


### PR DESCRIPTION
Supersedes #32.

#### Breaking change

* Tax and benefit system evolution.
* Impacted periods: all.
* Impacted areas: `variables/housing`
* Details:
  - Fix spelling by renaming `accomodation_size` variable to `accommodation_size`

#### Other changes

* Minor change.
* Impacted areas: no functional impact.
* Details:
  - Improved spelling

- - - -

These changes:

- Impact the OpenFisca-Country-Template public API (for instance renaming or removing a variable)
- Change non-functional parts of this repository (for instance editing the README)