### PR TITLE
Improve installation procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 3.1.3 - [#37](https://github.com/openfisca/country-template/pull/37)
+
+* Minor change.
+* Impacted areas: no functional impact.
+* Details:
+  - Upgrade openfisca.org references to HTTPS.
+
 ### 3.1.2 - [#38](https://github.com/openfisca/country-template/pull/38)
 
 * Add situation example using YAML
@@ -11,7 +18,7 @@
 * Details:
   - Continuously deploy Python3 package.
 
-### 3.1.0 - [#41](https://github.com/openfisca/country-template/pull/41)
+## 3.1.0 - [#41](https://github.com/openfisca/country-template/pull/41)
 
 * Make package compatible with Python 3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@
 
 ### 3.0.2 - [#37](https://github.com/openfisca/country-template/pull/37)
 
+* Technical change.
+* Impacted periods: all.
+* Impacted areas: all.
 * Declare package compatible with OpenFisca Core v23
 
 ### 3.0.1 - [#39](https://github.com/openfisca/country-template/pull/39)
 
+* Technical change.
+* Impacted periods: all.
+* Impacted areas: all.
 * Declare package compatible with OpenFisca Core v22
 
 # 3.0.0 - [#34](https://github.com/openfisca/country-template/pull/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
 
 ### 3.1.2 - [#38](https://github.com/openfisca/country-template/pull/38)
 
-* Add situation example using YAML
+* Minor change.
+* Impacted areas: no functional impact.
+* Details:
+  - Add situation example using YAML
 
 ### 3.1.1 - [#44](https://github.com/openfisca/country-template/pull/44)
 
@@ -20,7 +23,10 @@
 
 ## 3.1.0 - [#41](https://github.com/openfisca/country-template/pull/41)
 
-* Make package compatible with Python 3
+* Technical improvement.
+* Impacted areas: all.
+* Details:
+  - Make package compatible with Python 3
 
 ### 3.0.2 - [#37](https://github.com/openfisca/country-template/pull/37)
 

--- a/README.md
+++ b/README.md
@@ -164,15 +164,11 @@ Clone this Country Package on your machine:
 ```sh
 git clone https://github.com/openfisca/openfisca-country-template.git
 cd openfisca-country-template
-pip install -e .
+pip install --editable .[test]
 ```
 
-You can make sure that everything is working by running the provided tests:
+You can make sure that everything is working by running the provided tests with `make test`.
 
-```sh
-pip install -e ".[test]"
-make test
-```
 > [Learn more about tests](http://openfisca.org/doc/coding-the-legislation/writing_yaml_tests.html)
 
 :tada: This OpenFisca Country Package is now installed and ready!

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Additional information:
 
 :tada: You are now ready to install this OpenFisca Country Package!
 
-We offer 2 install procedures. Pick procedure A or B below depending on how you plan to use this Country Package. 
+We offer 2 install procedures. Pick procedure A or B below depending on how you plan to use this Country Package.
 
 ### A. Minimal Installation (Pip Install)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # OpenFisca Country-Template
 
-This repository is here to help you quickly bootstrap and use your own OpenFisca country package.
+This repository helps you quickly bootstrap and use your own OpenFisca country package.
+
 
 ## Bootstrapping your Country Package
 
-This set of instructions will create your own copy of this boilerplate directory and customise it to the country you want to work on:
+This set of instructions will create your own copy of this boilerplate directory and customise it to the country you want to work on. You will need to have [Git](https://git-scm.com) installed.
 
 ```sh
 COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores
@@ -49,51 +50,37 @@ Country packages are python distributions. To distribute your package via `pip`,
 
 ## Install Instructions for Users and Contributors
 
-This package requires [Python 2.7](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/stable/installing/) .
+This package requires [Python 2.7.9](https://www.python.org/downloads/release/python-2715/) or a more recent 2.7 version.
 
-Supported platforms:
-- GNU/Linux distributions (in particular Debian and Ubuntu);
-- Mac OS X;
-- Microsoft Windows (we recommend using [ConEmu](https://conemu.github.io/) instead of the default console).
-
-Other OS should work if they can execute Python and NumPy.
+All platforms that can execute Python are supported, which includes GNU/Linux, macOS and Microsoft Windows (in which case we recommend using [ConEmu](https://conemu.github.io/) instead of the default console).
 
 ### Setting-up a Virtual Environment with Pew
 
-We recommend using a [virtual environment](https://virtualenv.pypa.io/en/stable/) (abbreviated as "virtualenv") with a virtualenv manager such as [pew](https://github.com/berdario/pew).
+In order to limit dependencies conflicts, we recommend to use a [virtual environment](https://virtualenv.pypa.io/en/stable/) (abbreviated as “virtualenv”) with a virtualenv manager such as [pew](https://github.com/berdario/pew).
 
 - A [virtualenv](https://virtualenv.pypa.io/en/stable/) is a project specific environment created to suit the needs of the project you are working on.
-- A virtualenv manager, such as [pew](https://github.com/berdario/pew), lets you easily create, remove and toggle between several virtualenvs.
+- A virtualenv manager such as [pew](https://github.com/berdario/pew) lets you easily create, remove and toggle between several virtualenvs.
 
 To install pew, launch a terminal on your computer and follow these instructions:
 
 ```sh
-python --version # You should have python 2.7.9 or better installed on your computer.
-# If not, visit http://www.python.org to install it and install pip as well.
-```
-
-```sh
 pip install --upgrade pip
 pip install pew  # if asked, answer "Y" to the question about modifying your shell config file.
-```
-To set-up and create a new a virtualenv named **openfisca** running python2.7:
-
-```sh
-pew new openfisca --python=python2.7
+pew new openfisca --python=python2.7  # create a new virtualenv called “openfisca”
 ```
 
 The virtualenv you just created will be automatically activated. This means you will operate in the virtualenv immediately. You should see a prompt resembling this:
-```sh
+
+```
 Installing setuptools, pip, wheel...done.
 Launching subshell in virtual environment. Type 'exit' or 'Ctrl+D' to return.
 ```
-Additional information:
-- Exit the virtualenv with `exit` (or Ctrl-D).
-- Re-enter with `pew workon openfisca`.
+
+You can re-activate that virtualenv at any time with `pew workon openfisca`.
 
 :tada: You are now ready to install this OpenFisca Country Package!
 
-We offer 2 install procedures. Pick procedure A or B below depending on how you plan to use this Country Package.
+Two install procedures are available. Pick procedure A or B below depending on how you plan to use this Country Package.
 
 ### A. Minimal Installation (Pip Install)
 

--- a/README.md
+++ b/README.md
@@ -2,30 +2,26 @@
 
 This repository helps you quickly bootstrap and use your own OpenFisca country package.
 
+**You should NOT fork it but [download a copy](https://github.com/openfisca/country-template/archive/master.zip) of it** and follow the bootstrapping instructions below.
+
+> Otherwise, you will have to clean up all tags when you deploy your own country package.
+
 
 ## Bootstrapping your Country Package
 
 This set of instructions will create your own copy of this boilerplate directory and customise it to the country you want to work on. You will need to have [Git](https://git-scm.com) installed.
 
+First, [download a copy](https://github.com/openfisca/country-template/archive/master.zip) of this repository, unzip it and `cd` into it in a Terminal window.
+
+Then, set up the two following variables and execute the `bootstrap.sh` script to initialise a new Git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
+
 ```sh
-COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores
-URL=https://github.com/openfisca/openfisca-france  # set here the URL of the repository where you will publish your code.
-
-lowercase_country_name=$(echo $COUNTRY_NAME | tr '[:upper:]' '[:lower:]')
-
-git clone https://github.com/openfisca/country-template.git  # download this template code
-
-# remove all references to `openfisca_country_template` in the code base:
-mv country-template openfisca-$lowercase_country_name
-cd openfisca-$lowercase_country_name
-git remote remove origin
-sed -i '' '3,28d' README.md  # Remove these instructions lines
-sed -i '' "s|country_template|$lowercase_country_name|g" README.md setup.py check-version-bump.sh Makefile `find openfisca_country_template -type f`
-sed -i '' "s|country-template|$lowercase_country_name|g" README.md
-sed -i '' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py check-version-bump.sh .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md `find openfisca_country_template -type f`
-sed -i '' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
-mv openfisca_country_template openfisca_$lowercase_country_name
+export COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores
+export URL=https://github.com/$YOUR_ORGANISATION/OpenFisca-$COUNTRY_NAME  # set here the URL of the repository where you will publish your code.
+./bootstrap.sh
 ```
+
+That's it, you're all set!
 
 ## Writing the Legislation
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ pip install openfisca_country_template
 
 #### Next Steps
 
-- To learn how to use OpenFisca, follow our [tutorials](http://openfisca.org/doc/).
+- To learn how to use OpenFisca, follow our [tutorials](https://openfisca.org/doc/).
 - To serve this Country Package, serve the [OpenFisca web API](#serve-your-country-package-with-the-openFisca-web-api).
 
 Depending on what you want to do with OpenFisca, you may want to install yet other packages in your virtualenv:
-- To install extensions or write on top of this Country Package, head to the [Extensions documentation](http://openfisca.org/doc/contribute/extensions.html).
+- To install extensions or write on top of this Country Package, head to the [Extensions documentation](https://openfisca.org/doc/contribute/extensions.html).
 - To plot simulation results, try [matplotlib](http://matplotlib.org/).
 - To manage data, check out [pandas](http://pandas.pydata.org/).
 
@@ -169,14 +169,14 @@ pip install --editable .[test]
 
 You can make sure that everything is working by running the provided tests with `make test`.
 
-> [Learn more about tests](http://openfisca.org/doc/coding-the-legislation/writing_yaml_tests.html)
+> [Learn more about tests](https://openfisca.org/doc/coding-the-legislation/writing_yaml_tests.html)
 
 :tada: This OpenFisca Country Package is now installed and ready!
 
 #### Next Steps
 
-- To write new legislation, read the [Coding the legislation](http://openfisca.org/doc/coding-the-legislation/index.html) section to know how to write legislation.
-- To contribute to the code, read our [Contribution Guidebook](http://openfisca.org/doc/contribute/index.html).
+- To write new legislation, read the [Coding the legislation](https://openfisca.org/doc/coding-the-legislation/index.html) section to know how to write legislation.
+- To contribute to the code, read our [Contribution Guidebook](https://openfisca.org/doc/contribute/index.html).
 
 ## Serve this Country Package with the OpenFisca Web API
 
@@ -198,4 +198,4 @@ curl "http://localhost:5000/spec"
 
 This endpoint returns the [Open API specification](https://www.openapis.org/) of your API.
 
-:tada: This OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](http://openfisca.org/doc/openfisca-web-api/index.html)
+:tada: This OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](https://openfisca.org/doc/openfisca-web-api/index.html)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+if ! test $COUNTRY_NAME || ! test $URL
+then
+	echo 'You need to define COUNTRY_NAME and URL first  ;)'
+	exit 1
+fi
+
+cd $(dirname $0)  # support being called from anywhere on the file system
+
+if [[ -d .git ]]
+then
+	echo 'It seems you cloned this repository, or already initialised it.'
+	echo 'Refusing to go further as you might lose work.'
+	echo "If you are certain this is a new repository, run 'cd $(dirname $0) && rm -rf .git' to erase the history."
+	exit 2
+fi
+
+lowercase_country_name=$(echo $COUNTRY_NAME | tr '[:upper:]' '[:lower:]')
+last_bootstrapping_line_number=$(grep --line-number '^## Writing the Legislation' README.md | cut -d ':' -f 1)
+
+cd ..
+pwd
+mv country-template openfisca-$lowercase_country_name
+cd openfisca-$lowercase_country_name
+
+git init
+git add .
+git commit --message 'Initial import from OpenFisca country-template' --author='OpenFisca Bot <bot@openfisca.org>'
+
+sed -i '' "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
+sed -i '' "s|country_template|$lowercase_country_name|g" README.md setup.py check-version-bump.sh Makefile `find openfisca_country_template -type f`
+sed -i '' "s|country-template|$lowercase_country_name|g" README.md
+sed -i '' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py check-version-bump.sh .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md `find openfisca_country_template -type f`
+sed -i '' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
+git mv openfisca_country_template openfisca_$lowercase_country_name
+
+git rm bootstrap.sh
+git add .
+git commit --message 'Customise country-template through script' --author='OpenFisca Bot <bot@openfisca.org>'
+git remote add origin $URL.git
+
+echo '************'
+echo '* All set! *'
+echo '************'

--- a/openfisca_country_template/entities.py
+++ b/openfisca_country_template/entities.py
@@ -19,7 +19,7 @@ Household = build_entity(
     Check the number of individuals of a specific role (e.g. check if there is a 'second_parent' with household.nb_persons(Household.SECOND_PARENT)).
     Calculate a variable applied to each individual of the group entity (e.g. calculate the 'salary' of each member of the 'Household' with salaries = household.members('salary', period = MONTH); sum_salaries = household.sum(salaries)).
 
-    For more information, see: http://openfisca.org/doc/coding-the-legislation/50_entities.html
+    For more information, see: https://openfisca.org/doc/coding-the-legislation/50_entities.html
     ''',
     roles = [
         {
@@ -53,7 +53,7 @@ Person = build_entity(
     Calculate a variable applied to a 'Person' (e.g. access the 'salary' of a specific month with person('salary', "2017-05")).
     Check the role of a 'Person' in a group entity (e.g. check if a the 'Person' is a 'first_parent' in a 'Household' entity with person.has_role(Household.FIRST_PARENT)).
 
-    For more information, see: http://openfisca.org/doc/coding-the-legislation/50_entities.html
+    For more information, see: https://openfisca.org/doc/coding-the-legislation/50_entities.html
     ''',
     is_person = True,
     )

--- a/openfisca_country_template/reforms/flat_social_security_contribution.py
+++ b/openfisca_country_template/reforms/flat_social_security_contribution.py
@@ -2,7 +2,7 @@
 
 # This file defines a reform.
 # A reform is a set of modifications to be applied to a reference tax and benefit system to carry out experiments.
-# See http://openfisca.org/doc/reforms.html
+# See https://openfisca.org/doc/reforms.html
 
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
@@ -19,6 +19,6 @@ class social_security_contribution(Variable):
 
 class flat_social_security_contribution(Reform):
     # A reform always defines an `apply` method that builds the reformed tax and benefit system from the reference one.
-    # See http://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
+    # See https://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
     def apply(self):
         self.update_variable(social_security_contribution)

--- a/openfisca_country_template/reforms/modify_social_security_taxation.py
+++ b/openfisca_country_template/reforms/modify_social_security_taxation.py
@@ -2,7 +2,7 @@
 
 # This file defines a reform.
 # A reform is a set of modifications to be applied to a reference tax and benefit system to carry out experiments.
-# See http://openfisca.org/doc/reforms.html
+# See https://openfisca.org/doc/reforms.html
 
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
@@ -11,12 +11,12 @@ from openfisca_core.model_api import *
 
 class modify_social_security_taxation(Reform):
     # A reform always defines an `apply` method that builds the reformed tax and benefit system from the reference one.
-    # See http://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
+    # See https://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
     def apply(self):
         # Our reform modifies the `social_security_contribution` parameter, which is a scale.
         # This parameter is declared in `parameters/taxes/social_security_contribution.yaml`.
         #
-        # See http://openfisca.org/doc/coding-the-legislation/legislation_parameters.html
+        # See https://openfisca.org/doc/coding-the-legislation/legislation_parameters.html
         self.modify_parameters(modifier_function=self.modify_brackets)
 
     def modify_brackets(self, parameters):

--- a/openfisca_country_template/reforms/removal_basic_income.py
+++ b/openfisca_country_template/reforms/removal_basic_income.py
@@ -2,7 +2,7 @@
 
 # This file defines a reform.
 # A reform is a set of modifications to be applied to a reference tax and benefit system to carry out experiments.
-# See http://openfisca.org/doc/reforms.html
+# See https://openfisca.org/doc/reforms.html
 
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
@@ -11,7 +11,7 @@ from openfisca_core.model_api import *
 
 class removal_basic_income(Reform):
     # A reform always defines an `apply` method that builds the reformed tax and benefit system from the reference one.
-    # See http://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
+    # See https://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
     def apply(self):
         # Our reform neutralizes the `basic_income` variable. When this reform is applied, calculating `basic_income` will always return its default value, 0.
         self.neutralize_variable('basic_income')

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -2,7 +2,7 @@
 
 # This file defines the variables of our legislation.
 # A variable is property of a person, or an entity (e.g. a household).
-# See http://openfisca.org/doc/variables.html
+# See https://openfisca.org/doc/variables.html
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *
@@ -20,14 +20,14 @@ class basic_income(Variable):
     # Since Dec 1st 2016, the basic income is provided to any adult, without considering their income.
     def formula_2016_12(person, period, parameters):
         age_condition = person('age', period) >= parameters(period).general.age_of_majority
-        return age_condition * parameters(period).benefits.basic_income  # This '*' is a vectorial 'if'. See http://openfisca.org/doc/coding-the-legislation/30_case_disjunction.html#simple-multiplication
+        return age_condition * parameters(period).benefits.basic_income  # This '*' is a vectorial 'if'. See https://openfisca.org/doc/coding-the-legislation/30_case_disjunction.html#simple-multiplication
 
     # From Dec 1st 2015 to Nov 30 2016, the basic income is provided to adults who have no income.
     # Before Dec 1st 2015, the basic income does not exist in the law, and calculating it returns its default value, which is 0.
     def formula_2015_12(person, period, parameters):
         age_condition = person('age', period) >= parameters(period).general.age_of_majority
         salary_condition = person('salary', period) == 0
-        return age_condition * salary_condition * parameters(period).benefits.basic_income  # The '*' is also used as a vectorial 'and'. See http://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html#forbidden-operations-and-alternatives
+        return age_condition * salary_condition * parameters(period).benefits.basic_income  # The '*' is also used as a vectorial 'and'. See https://openfisca.org/doc/coding-the-legislation/25_vectorial_computing.html#forbidden-operations-and-alternatives
 
 
 class housing_allowance(Variable):

--- a/openfisca_country_template/variables/demographics.py
+++ b/openfisca_country_template/variables/demographics.py
@@ -2,7 +2,7 @@
 
 # This file defines the variables of our legislation.
 # A variable is property of a person, or an entity (e.g. a household).
-# See http://openfisca.org/doc/variables.html
+# See https://openfisca.org/doc/variables.html
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -2,7 +2,7 @@
 
 # This file defines the variables of our legislation.
 # A variable is property of a person, or an entity (e.g. a household).
-# See http://openfisca.org/doc/variables.html
+# See https://openfisca.org/doc/variables.html
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *

--- a/openfisca_country_template/variables/income.py
+++ b/openfisca_country_template/variables/income.py
@@ -2,7 +2,7 @@
 
 # This file defines the variables of our legislation.
 # A variable is property of a person, or an entity (e.g. a household).
-# See http://openfisca.org/doc/variables.html
+# See https://openfisca.org/doc/variables.html
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *

--- a/openfisca_country_template/variables/stats.py
+++ b/openfisca_country_template/variables/stats.py
@@ -2,7 +2,7 @@
 
 # This file defines the variables of our legislation.
 # A variable is property of a person, or an entity (e.g. a household).
-# See http://openfisca.org/doc/variables.html
+# See https://openfisca.org/doc/variables.html
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -2,7 +2,7 @@
 
 # This file defines the variables of our legislation.
 # A variable is property of a person, or an entity (e.g. a household).
-# See http://openfisca.org/doc/variables.html
+# See https://openfisca.org/doc/variables.html
 
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *
@@ -48,7 +48,7 @@ class housing_tax(Variable):
     def formula(household, period, parameters):
         # The housing tax is defined for a year, but depends on the `accommodation_size` and `housing_occupancy_status` on the first month of the year.
         # Here period is a year. We can get the first month of a year with the following shortcut.
-        # To build different periods, see http://openfisca.org/doc/coding-the-legislation/35_periods.html#calculating-dependencies-for-a-specific-period
+        # To build different periods, see https://openfisca.org/doc/coding-the-legislation/35_periods.html#calculating-dependencies-for-a-specific-period
         january = period.first_month
         accommodation_size = household('accommodation_size', january)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='3.1.2',
+    version='3.1.3',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',


### PR DESCRIPTION
The current instructions recommend to clone the country-template. However, that means inheriting a whole history and, even more annoyingly, tags. These version tags will conflict with the actual country package version tags unless they build upon the existing ones, which don't make sense at all as one of the first actions when publishing is to remove all the boilerplate files.

This changeset:

- Recommends to download a copy of the repository contents rather than to clone it.
- Extracts and makes more resilient the bootstrapping script.
- Simplifies some of the wording and removes redundancy in some instructions.
- Switches all openfisca.org URLs to HTTPS.