### PR TITLE
Fix compatibility issues in bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 3.2.1 - [#47](https://github.com/openfisca/country-template/pull/47)
+
+* Minor change.
+* Impacted areas: no functional impact.
+* Details:
+  - Fix boostrap script.
+
 ## 3.2.0 - [#43](https://github.com/openfisca/country-template/pull/43)
 
 * Tax and benefit system evolution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### 3.2.1 - [#47](https://github.com/openfisca/country-template/pull/47)
 
 * Minor change.
-* Impacted areas: no functional impact.
 * Details:
   - Make boostrap script portable.
 
@@ -19,43 +18,35 @@
 ### 3.1.3 - [#37](https://github.com/openfisca/country-template/pull/37)
 
 * Minor change.
-* Impacted areas: no functional impact.
 * Details:
   - Upgrade openfisca.org references to HTTPS.
 
 ### 3.1.2 - [#38](https://github.com/openfisca/country-template/pull/38)
 
 * Minor change.
-* Impacted areas: no functional impact.
 * Details:
   - Add situation example using YAML
 
 ### 3.1.1 - [#44](https://github.com/openfisca/country-template/pull/44)
 
 * Technical improvement.
-* Impacted areas: deployment.
 * Details:
   - Continuously deploy Python3 package.
 
 ## 3.1.0 - [#41](https://github.com/openfisca/country-template/pull/41)
 
 * Technical improvement.
-* Impacted areas: all.
 * Details:
   - Make package compatible with Python 3
 
 ### 3.0.2 - [#37](https://github.com/openfisca/country-template/pull/37)
 
 * Technical change.
-* Impacted periods: all.
-* Impacted areas: all.
 * Declare package compatible with OpenFisca Core v23
 
 ### 3.0.1 - [#39](https://github.com/openfisca/country-template/pull/39)
 
 * Technical change.
-* Impacted periods: all.
-* Impacted areas: all.
 * Declare package compatible with OpenFisca Core v22
 
 # 3.0.0 - [#34](https://github.com/openfisca/country-template/pull/34)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Minor change.
 * Impacted areas: no functional impact.
 * Details:
-  - Fix boostrap script.
+  - Make boostrap script portable.
 
 ## 3.2.0 - [#43](https://github.com/openfisca/country-template/pull/43)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then, set up the two following variables and execute the `bootstrap.sh` script t
 
 ```sh
 export COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores
-export URL=https://github.com/$YOUR_ORGANISATION/OpenFisca-$COUNTRY_NAME  # set here the URL of the repository where you will publish your code.
+export REPOSITORY_URL=https://github.com/YOUR_ORGANISATION/OpenFisca-$COUNTRY_NAME  # set here the URL of the repository where you will publish your code.
 ./bootstrap.sh
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,7 +4,7 @@ set -e
 
 if ! test $COUNTRY_NAME || ! test $REPOSITORY_URL
 then
-	echo 'You need to define COUNTRY_NAME and REPOSITORY_URL first  ;)'
+	echo 'You need to define and export COUNTRY_NAME and REPOSITORY_URL first  ;)'
 	echo 'Open README.md for more information.'
 	exit 1
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,11 +30,16 @@ git init
 git add .
 git commit --message 'Initial import from OpenFisca country-template' --author='OpenFisca Bot <bot@openfisca.org>'
 
-sed -i -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
-sed -i "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile `find openfisca_country_template -type f`
-sed -i "s|country-template|$lowercase_country_name|g" README.md
-sed -i "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md `find openfisca_country_template -type f`
-sed -i "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
+all_module_files=`find openfisca_country_template -type f`
+
+# Use intermediate backup files due to lack of portable 'no backup' option. See https://stackoverflow.com/q/5694228/594053
+sed -i '.template' "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile $all_module_files
+sed -i '.template' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md $all_module_files
+sed -i '.template' -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
+sed -i '.template' "s|country-template|$lowercase_country_name|g" README.md
+sed -i '.template' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
+find . -name "*.template" -type f -delete
+
 git mv openfisca_country_template openfisca_$lowercase_country_name
 
 git rm bootstrap.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,9 +2,10 @@
 
 set -e
 
-if ! test $COUNTRY_NAME || ! test $URL
+if ! test $COUNTRY_NAME || ! test $REPOSITORY_URL
 then
-	echo 'You need to define COUNTRY_NAME and URL first  ;)'
+	echo 'You need to define COUNTRY_NAME and REPOSITORY_URL first  ;)'
+	echo 'Open README.md for more information.'
 	exit 1
 fi
 
@@ -49,7 +50,7 @@ git mv openfisca_country_template openfisca_$lowercase_country_name
 git rm bootstrap.sh
 git add .
 git commit --message 'Customise country-template through script' --author='OpenFisca Bot <bot@openfisca.org>'
-git remote add origin $URL.git
+git remote add origin $REPOSITORY_URL.git
 
 echo '************'
 echo '* All set! *'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -35,12 +35,12 @@ all_module_files=`find openfisca_country_template -type f`
 
 set -x
 
-# Use intermediate backup files due to lack of portable 'no backup' option. See https://stackoverflow.com/q/5694228/594053
-sed -i '.template' "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile $all_module_files
-sed -i '.template' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md $all_module_files
-sed -i '.template' -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
-sed -i '.template' "s|country-template|$lowercase_country_name|g" README.md
-sed -i '.template' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
+# Use intermediate backup files (`-i`) with a weird syntax due to lack of portable 'no backup' option. See https://stackoverflow.com/q/5694228/594053.
+sed -i.template "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile $all_module_files
+sed -i.template "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md $all_module_files
+sed -i.template -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
+sed -i.template "s|country-template|$lowercase_country_name|g" README.md
+sed -i.template "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
 find . -name "*.template" -type f -delete
 
 set +x

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,18 +23,18 @@ last_bootstrapping_line_number=$(grep --line-number '^## Writing the Legislation
 
 cd ..
 pwd
-mv country-template openfisca-$lowercase_country_name
+mv country-template-master openfisca-$lowercase_country_name
 cd openfisca-$lowercase_country_name
 
 git init
 git add .
 git commit --message 'Initial import from OpenFisca country-template' --author='OpenFisca Bot <bot@openfisca.org>'
 
-sed -i '' "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
-sed -i '' "s|country_template|$lowercase_country_name|g" README.md setup.py check-version-bump.sh Makefile `find openfisca_country_template -type f`
-sed -i '' "s|country-template|$lowercase_country_name|g" README.md
-sed -i '' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py check-version-bump.sh .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md `find openfisca_country_template -type f`
-sed -i '' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
+sed -i -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
+sed -i "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile `find openfisca_country_template -type f`
+sed -i "s|country-template|$lowercase_country_name|g" README.md
+sed -i "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md `find openfisca_country_template -type f`
+sed -i "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
 git mv openfisca_country_template openfisca_$lowercase_country_name
 
 git rm bootstrap.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,6 +32,8 @@ git commit --message 'Initial import from OpenFisca country-template' --author='
 
 all_module_files=`find openfisca_country_template -type f`
 
+set -x
+
 # Use intermediate backup files due to lack of portable 'no backup' option. See https://stackoverflow.com/q/5694228/594053
 sed -i '.template' "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile $all_module_files
 sed -i '.template' "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md $all_module_files
@@ -39,6 +41,8 @@ sed -i '.template' -e "3,${last_bootstrapping_line_number}d" README.md  # remove
 sed -i '.template' "s|country-template|$lowercase_country_name|g" README.md
 sed -i '.template' "s|https://github.com/openfisca/openfisca-country-template|$URL|g" setup.py
 find . -name "*.template" -type f -delete
+
+set +x
 
 git mv openfisca_country_template openfisca_$lowercase_country_name
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,7 +29,7 @@ cd openfisca-$lowercase_country_name
 
 git init
 git add .
-git commit --message 'Initial import from OpenFisca country-template' --author='OpenFisca Bot <bot@openfisca.org>'
+git commit --no-gpg-sign --message 'Initial import from OpenFisca country-template' --author='OpenFisca Bot <bot@openfisca.org>'
 
 all_module_files=`find openfisca_country_template -type f`
 
@@ -49,7 +49,7 @@ git mv openfisca_country_template openfisca_$lowercase_country_name
 
 git rm bootstrap.sh
 git add .
-git commit --message 'Customise country-template through script' --author='OpenFisca Bot <bot@openfisca.org>'
+git commit --no-gpg-sign --message 'Customise country-template through script' --author='OpenFisca Bot <bot@openfisca.org>'
 git remote add origin $REPOSITORY_URL.git
 
 echo '************'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='3.2.0',
+    version='3.2.1',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',


### PR DESCRIPTION
* Since the user copies an archive, rename `country-template-master` instead of `country-template` 
* Fix some compatibility issues with the `sed` of mac and the `sed` of linux.
* Do not change the nonexistent script `check-version-bump.sh`

NB: I am not sure theses changes don't break on mac.