### PR TITLE
Add editorial content on parameter and variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 3.3.1 - [#53](https://github.com/openfisca/country-template/pull/53)
+
+* Minor change
+* Details:
+  - Add `documentation` to parameters: `benefits` node and `benefits/housing_allowance`
+  - Add documentation to `housing_allowance` variable and formula
+
 ### 3.3.0 - [#51](https://github.com/openfisca/country-template/pull/51)
 
 * Technical change

--- a/openfisca_country_template/parameters/benefits/housing_allowance.yaml
+++ b/openfisca_country_template/parameters/benefits/housing_allowance.yaml
@@ -1,6 +1,10 @@
 description: Housing allowance amount (as a fraction of the rent)
 metadata:
   unit: /1
+  reference: https://law.gov.example/housing-allowance-rate
+  doc: "This is
+  some documentation
+  on multiple lines."
 values:
   # This parameter is only defined from the 1st of Jan 2010 to the 3Oth of Nov 2016.
   2010-01-01:

--- a/openfisca_country_template/parameters/benefits/housing_allowance.yaml
+++ b/openfisca_country_template/parameters/benefits/housing_allowance.yaml
@@ -2,9 +2,9 @@ description: Housing allowance amount (as a fraction of the rent)
 metadata:
   unit: /1
   reference: https://law.gov.example/housing-allowance-rate
-  doc: "This is
-  some documentation
-  on multiple lines."
+documentation: |
+  A fraction of the rent.
+  From the 1st of Dec 2016, the housing allowance no longer exists.
 values:
   # This parameter is only defined from the 1st of Jan 2010 to the 3Oth of Nov 2016.
   2010-01-01:

--- a/openfisca_country_template/parameters/benefits/index.yaml
+++ b/openfisca_country_template/parameters/benefits/index.yaml
@@ -1,3 +1,4 @@
 # This (optional) file defines metadata for the node parameters.benefits in the parameter tree.
 
 description: Social benefits
+documentation: This (optional) file defines metadata for the node parameters.benefits in the parameter tree.

--- a/openfisca_country_template/parameters/benefits/index.yaml
+++ b/openfisca_country_template/parameters/benefits/index.yaml
@@ -1,4 +1,9 @@
 # This (optional) file defines metadata for the node parameters.benefits in the parameter tree.
 
 description: Social benefits
-documentation: This (optional) file defines metadata for the node parameters.benefits in the parameter tree.
+documentation: |
+  Government support for the citizens and residents of society. 
+  They may be provided to people of any income level, as with social security, 
+  but usually it is intended to ensure that everyone can meet their basic human needs 
+  such as food and shelter.
+  (See https://en.wikipedia.org/wiki/Welfare)

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -38,7 +38,7 @@ class housing_allowance(Variable):
     reference = "https://law.gov.example/housing_allowance"  # Always use the most official source
     end = '2016-11-30'  # This allowance was removed on the 1st of Dec 2016. Calculating it before this date will always return the variable default value, 0.
     unit = 'currency-EUR'
-    doc = '''
+    documentation = '''
     This allowance was introduced on the 1st of Jan 1980.
     It needs the 'rent' value (same month) but doesn't care about the 'housing_occupancy_status'.
     '''

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -45,6 +45,7 @@ class housing_allowance(Variable):
 
     # This allowance was introduced on the 1st of Jan 1980. Calculating it before this date will always return the variable default value, 0.
     def formula_1980(household, period, parameters):
+        '''This is my specific life statement.'''
         return household('rent', period) * parameters(period).benefits.housing_allowance
 
 

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -40,12 +40,14 @@ class housing_allowance(Variable):
     unit = 'currency-EUR'
     documentation = '''
     This allowance was introduced on the 1st of Jan 1980.
-    It needs the 'rent' value (same month) but doesn't care about the 'housing_occupancy_status'.
+    It disappeared in Dec 2016.
     '''
 
     # This allowance was introduced on the 1st of Jan 1980. Calculating it before this date will always return the variable default value, 0.
     def formula_1980(household, period, parameters):
-        '''This is my specific life statement.'''
+        '''
+        To compute this allowance, the 'rent' value must be provided for the same month, but 'housing_occupancy_status' is not necessary.
+        '''
         return household('rent', period) * parameters(period).benefits.housing_allowance
 
 

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -37,6 +37,11 @@ class housing_allowance(Variable):
     label = "Housing allowance"
     reference = "https://law.gov.example/housing_allowance"  # Always use the most official source
     end = '2016-11-30'  # This allowance was removed on the 1st of Dec 2016. Calculating it before this date will always return the variable default value, 0.
+    unit = 'currency-EUR'
+    doc = '''
+    This allowance was introduced on the 1st of Jan 1980.
+    It needs the 'rent' value (same month) but doesn't care about the 'housing_occupancy_status'.
+    '''
 
     # This allowance was introduced on the 1st of Jan 1980. Calculating it before this date will always return the variable default value, 0.
     def formula_1980(household, period, parameters):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/openfisca/country-template',
     include_package_data = True,  # Will read MANIFEST.in
     install_requires=[
-        'OpenFisca-Core[web-api] >= 24.0, < 25.0',
+        'OpenFisca-Core[web-api] >= 24.4, < 25.0',
         ],
     extras_require = {
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Country-Template',
-    version='3.3.0',
+    version='3.3.1',
     author='OpenFisca Team',
     author_email='contact@openfisca.fr',
     description=u'OpenFisca tax and benefit system for Country-Template',


### PR DESCRIPTION
Connected to openfisca/legislation-explorer#124

Note : 
This branch was necessary to test openfisca/openfisca-core#717
Nevertheless, the question is: what do we want to keep as documentation example for new countries? 🙂 

- - - -

* Minor change
* Impacted areas: `parameters/benefits`, `parameters/benefits/housing_allowance` and `variables/benefits`
* Details:
  - Add `documentation` to parameters: `benefits` node and `benefits/housing_allowance`
  - Add `documentation` to `housing_allowance` variable and docstring to its formula

- - - -

These changes:

- Improve already existing parameter and variable *metadata*.

