### PR TITLE
Specify the bootstrap script doesn't create a repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This set of instructions will create your own copy of this boilerplate directory
 
 1. [download a copy](https://github.com/openfisca/country-template/archive/master.zip) of this repository, unzip it and `cd` into it in a Terminal window.
 
-2. reate a git repository where you will publish your code, as the bootstrapping script will need it to properly setup your new and shiny OpenFisca country (Github, BitBucket, GitLab, etc.).
+2. Create a new repository on your favourite git host (Github, Bitbucket, GitLab, etc) with the name openfisca-your_country_name. For example, ```openfisca-france```.
 
-3. Set up the two following variables and execute the `bootstrap.sh` script to initialise the Git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
+3. Set up the two following variables and execute the `bootstrap.sh` script to initialise the git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
 
 ```sh
 export COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This set of instructions will create your own copy of this boilerplate directory
 
 1. [download a copy](https://github.com/openfisca/country-template/archive/master.zip) of this repository, unzip it and `cd` into it in a Terminal window.
 
-2. Create a new repository on your favourite git host (Github, Bitbucket, GitLab, etc) with the name openfisca-your_country_name. For example, ```openfisca-france```.
+2. Create a new repository on your favourite git host (Github, Bitbucket, GitLab, etc) with the name openfisca-your_country_name. For example, `openfisca-france`.
 
 3. Set up the two following variables and execute the `bootstrap.sh` script to initialise the git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
 
@@ -21,6 +21,12 @@ This set of instructions will create your own copy of this boilerplate directory
 export COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores
 export REPOSITORY_URL=https://github.com/YOUR_ORGANISATION/OpenFisca-$COUNTRY_NAME  # set here the URL of the repository you created in step 2.
 ./bootstrap.sh
+```
+
+4. Push your changes to your git host:
+
+```sh
+git push origin master
 ```
 
 That's it, you're all set!

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This set of instructions will create your own copy of this boilerplate directory
 
 2. reate a git repository where you will publish your code, as the bootstrapping script will need it to properly setup your new and shiny OpenFisca country (Github, BitBucket, GitLab, etc.).
 
-3. Set up the two following variables and execute the `bootstrap.sh` script to initialise a new Git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
+3. Set up the two following variables and execute the `bootstrap.sh` script to initialise the Git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
 
 ```sh
 export COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ This repository helps you quickly bootstrap and use your own OpenFisca country p
 
 This set of instructions will create your own copy of this boilerplate directory and customise it to the country you want to work on. You will need to have [Git](https://git-scm.com) installed.
 
-First, [download a copy](https://github.com/openfisca/country-template/archive/master.zip) of this repository, unzip it and `cd` into it in a Terminal window.
+1. [download a copy](https://github.com/openfisca/country-template/archive/master.zip) of this repository, unzip it and `cd` into it in a Terminal window.
 
-Then, set up the two following variables and execute the `bootstrap.sh` script to initialise a new Git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
+2. reate a git repository where you will publish your code, as the bootstrapping script will need it to properly setup your new and shiny OpenFisca country (Github, BitBucket, GitLab, etc.).
+
+3. Set up the two following variables and execute the `bootstrap.sh` script to initialise a new Git repository and replace all references to `openfisca_country_template` with references to your new country package in the code base:
 
 ```sh
 export COUNTRY_NAME=France  # set the name of your country here; you should keep all capitals, and replace any spaces in the name by underscores
-export REPOSITORY_URL=https://github.com/YOUR_ORGANISATION/OpenFisca-$COUNTRY_NAME  # set here the URL of the repository where you will publish your code.
+export REPOSITORY_URL=https://github.com/YOUR_ORGANISATION/OpenFisca-$COUNTRY_NAME  # set here the URL of the repository you created in step 2.
 ./bootstrap.sh
 ```
 


### PR DESCRIPTION
* Minor change.
* Impacted areas: `README.md`
* Details:
  - Specify the bootstrap script doesn't create a repo

- - - -

These changes:

- Change non-functional parts of this repository (for instance editing the README)
