### PR TITLE
Add housing.json file to situation examples; add to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 3.9.8 - [#83](https://github.com/openfisca/country-template/pull/83)
+
+* Minor change.
+* Details:
+  - Add additional example JSON file; add to README.
+
 ### 3.9.7 - [#80](https://github.com/openfisca/country-template/pull/80)
 
 * Minor change.

--- a/README.md
+++ b/README.md
@@ -181,4 +181,14 @@ curl "http://localhost:5000/spec"
 
 This endpoint returns the [Open API specification](https://www.openapis.org/) of your API.
 
-:tada: This OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](https://openfisca.org/doc/openfisca-web-api/index.html)
+:tada: This OpenFisca Country Package is now served by the OpenFisca Web API! To learn more, go to the [OpenFisca Web API documentation](https://openfisca.org/doc/openfisca-web-api/index.html).
+
+You can test your new Web API by sending it example JSON data located in the `situation_examples` folder.
+
+Substitute your package's country name for `openfisca_country_template` below:
+
+```sh
+curl -X POST -H "Content-Type: application/json" \
+  -d @./openfisca_country_template/situation_examples/couple.json \
+  http://localhost:5000/calculate
+```

--- a/openfisca_country_template/situation_examples/housing.json
+++ b/openfisca_country_template/situation_examples/housing.json
@@ -1,0 +1,23 @@
+{
+    "persons": {
+        "Alicia": {
+            "birth": {
+                "2017-01": null
+            },
+            "disposable_income": {
+                "2017-01": null
+            }
+        }
+    },
+    "households": {
+        "_": {
+            "parents": ["Alicia"],
+            "housing_tax": {
+                "2017": null
+            },
+            "housing_occupancy_status": {
+                "2017-01": null
+            }
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.9.7",
+    version = "3.9.8",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
* Minor change -- Documentation and example JSON. 
* Details:
  - Add new housing example JSON to `situation_examples` folder. The housing example uses the `Enum` type; goal is to help newcomers to the OpenFisca world discover this.
  - Update README with copy-pasteable `curl` command for sending example JSON to local Web API.

- - - -

Changes:

- Change non-functional parts of this repository (for instance editing the README).

- - - -

Thanks for considering this pull request! 

I opened it after reading @sandcha's reply here — https://github.com/openfisca/openfisca-core/issues/938#issuecomment-580168784 — which made me realize that I didn't fully understand all of the examples provided by this excellent template.

I know it's almost the weekend in Europe (and already the weekend in Asia-Pacific) — enjoy the weekend, no need to review this until next week or whenever there's capacity. 