### PR TITLE
Add `make serve-local` command to Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+### 3.9.9 - [#85](https://github.com/openfisca/country-template/pull/85)
+
+* Minor change.
+* Details:
+  - Add `make serve-local` command to Makefile.
+
 ### 3.9.8 - [#83](https://github.com/openfisca/country-template/pull/83)
 
 * Minor change.

--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,6 @@ check-style:
 
 test: clean check-syntax-errors check-style
 	openfisca-run-test --country-package openfisca_country_template openfisca_country_template/tests
+
+serve-local: build
+	openfisca serve --country-package openfisca_country_template

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ To serve the Openfisca Web API locally, run:
 openfisca serve --port 5000
 ```
 
+Or use the quick-start Make command:
+
+```
+make serve-local
+```
+
 To read more about the `openfisca serve` command, check out its [documentation](https://openfisca.org/doc/openfisca-python-api/openfisca_serve.html).
 
 You can make sure that your instance of the API is working by requesting:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.9.8",
+    version = "3.9.9",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
# What does this do?

Adds an additional command to the Makefile for quickly serving the API locally:

```
make serve-local
```

# Why? 

+ Makes the Makefile more comprehensive in terms of the commands it offers users.
+ Makes the command to serve the app discoverable via the Makefile.
+ Saves the user from remembering a custom-named command when getting started with a new OpenFisca project.

# Notes

+ The Makefile runs the `serve` command without any arguments as a form of quickstart; a user would need to run the full `openfisca serve` command if they want to send it command line arguments. 
+ Named the command `serve-local` under the assumption that users will want different config when serving in production.

- - - -

Minor change. These changes:

- Change non-functional parts of this repository (for instance editing the README).