### PR TITLE
Fix bug in bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Technical change.
 * Details:
-  - Fix bootstrap script bug.
+  - Fix installation and building operations by fixing the bootstrap script.
 
 ### 3.9.9 - [#85](https://github.com/openfisca/country-template/pull/85)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 3.9.10 - [#86](https://github.com/openfisca/country-template/pull/86)
+
+* Technical change.
+* Details:
+  - Fix bootstrap script bug.
 
 ### 3.9.9 - [#85](https://github.com/openfisca/country-template/pull/85)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,7 +36,7 @@ all_module_files=`find openfisca_country_template -type f`
 set -x
 
 # Use intermediate backup files (`-i`) with a weird syntax due to lack of portable 'no backup' option. See https://stackoverflow.com/q/5694228/594053.
-sed -i.template "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile $all_module_files
+sed -i.template "s|country_template|$lowercase_country_name|g" README.md setup.py .circleci/config.yml Makefile MANIFEST.in $all_module_files
 sed -i.template "s|Country-Template|$COUNTRY_NAME|g" README.md setup.py .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md $all_module_files
 sed -i.template -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
 sed -i.template "s|country-template|$lowercase_country_name|g" README.md

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.9.9",
+    version = "3.9.10",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
# Notes

*  Technical improvement. 
* Details:
  - This PR substitutes in the user-supplied country name for the default country name in the project `MANIFEST.in` file when the user runs the bootstrap script.
  - If the country name is not updated in `MANIFEST.in`, the correct dependencies will not be installed by `make install` and the project will not run.
  - I tested the bootstrap script on this branch and found that `make serve-local` (new command!) built, installed, and ran the project without issues; testing the same on the master branch resulted in an error.