### PR TITLE
Update numpy dependency version to 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-### 3.10.0 - [#98](https://github.com/openfisca/country-template/pull/98)
+## 3.11.0 - [#90](https://github.com/openfisca/country-template/pull/90)
+
+* Technical change
+* Details:
+  - Declare package compatible with OpenFisca-Core v35 that updates `numpy` dependency.
+
+## 3.10.0 - [#98](https://github.com/openfisca/country-template/pull/98)
 
 * Tax and benefit system evolution.
 * Impacted periods: all.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             ),
         ],
     install_requires = [
-        "OpenFisca-Core[web-api] >=27.0,<35.0",
+        "OpenFisca-Core[web-api] >=27.0,<36.0",
         ],
     extras_require = {
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.10.0",
+    version = "3.11.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
Connected to openfisca/openfisca-core#924

> To revert : CircleCI branch set to follow Core work in progress on numpy update.

---
* Technical improvement.
* Details:
  - Declare package compatible with OpenFisca-Core v35 that updates numpy dependency.
- - - -

These changes, coming with the numpy dependency update:

- Add a new feature (for instance adding a variable)
- Fix or improve an already existing calculation.
