### PR TITLE
Update OpenFisca test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 3.9.11 - [#94](https://github.com/openfisca/country-template/pull/94)
+
+* Minor change.
+* Details:
+  - Fix `make test` warning by updating OpenFisca test command.
+
 ### 3.9.10 - [#86](https://github.com/openfisca/country-template/pull/86)
 
 * Technical change.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ check-style:
 	flake8 `git ls-files | grep "\.py$$"`
 
 test: clean check-syntax-errors check-style
-	openfisca-run-test --country-package openfisca_country_template openfisca_country_template/tests
+	openfisca test --country-package openfisca_country_template openfisca_country_template/tests
 
 serve-local: build
 	openfisca serve --country-package openfisca_country_template

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.9.10",
+    version = "3.9.11",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
* Minor change.
* Details:
  - Fixes `make test` warning on OpenFisca test command (oops).

Warning example:

```bash
$ make test
rm -rf build dist
find . -name '*.pyc' -exec rm \{\} \;
python -m compileall -q .
flake8 `git ls-files | grep "\.py$"`
openfisca-run-test --country-package openfisca_country_template openfisca_country_template/tests
(...)/openfisca-core/openfisca_core/scripts/openfisca_command.py:57: Warning: The 'openfisca-run-test' command has been deprecated in favor of 'openfisca test' since version 25.0, and will be removed in the future.
  warnings.warn(message, Warning)
```

- - - -

These changes:
- Fix or improve an already existing operation.