### PR TITLE
Add reform example creating a new variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 3.10.0 - [#98](https://github.com/openfisca/country-template/pull/98)
+
+* Tax and benefit system evolution.
+* Impacted periods: all.
+* Impacted areas: `reforms/add_new_tax.py`
+* Details:
+  - Add a new reform example creating a variable (there was none prior)
+  - The example is a new tax that adds a fixed 100.0 of the country's currency to the actual income tax
+
 ### 3.9.13 - [#96](https://github.com/openfisca/country-template/pull/96)
 
 * Technical improvement.

--- a/openfisca_country_template/reforms/add_dynamic_variable.py
+++ b/openfisca_country_template/reforms/add_dynamic_variable.py
@@ -1,0 +1,61 @@
+"""
+This file defines a reform to add a dynamic variable, based on input data.
+
+A reform is a set of modifications to be applied to a reference tax and benefit system to carry out experiments.
+
+See https://openfisca.org/doc/key-concepts/reforms.html
+"""
+
+# Import from openfisca-core the Python objects used to code the legislation in OpenFisca
+from openfisca_core.periods import MONTH
+from openfisca_core.reforms import Reform
+from openfisca_core.variables import Variable
+
+# Import the Entities specifically defined for this tax and benefit system
+from openfisca_country_template.entities import Person
+
+
+def create_dynamic_variable(
+        name,
+        value_type,
+        entity,
+        default_value,
+        definition_period,
+        label,
+        reference,
+        ):
+    """Create new variable dynamically."""
+
+    NewVariable = type(name, (Variable,), {
+        "value_type": value_type,
+        "entity": entity,
+        "default_value": default_value,
+        "definition_period": definition_period,
+        "label": label,
+        "reference": reference,
+        })
+
+    return NewVariable
+
+
+class add_dynamic_variable(Reform):
+    def apply(self):
+        """
+        Apply reform.
+
+        A reform always defines an `apply` method that builds the reformed tax
+        and benefit system from the reference one.
+
+        See https://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
+        """
+        NewVariable = create_dynamic_variable(
+            name = "goes_to_school",
+            value_type = bool,
+            entity = Person,
+            default_value = True,
+            definition_period = MONTH,
+            label = "The person goes to school (only relevant for children)",
+            reference = "https://law.gov.example/goes_to_school",
+            )
+
+        self.add_variable(NewVariable)

--- a/openfisca_country_template/reforms/add_new_tax.py
+++ b/openfisca_country_template/reforms/add_new_tax.py
@@ -1,0 +1,45 @@
+"""
+This file defines a reform.
+
+A reform is a set of modifications to be applied to a reference tax and benefit system to carry out experiments.
+
+See https://openfisca.org/doc/key-concepts/reforms.html
+"""
+
+# Import from openfisca-core the Python objects used to code the legislation in OpenFisca
+from openfisca_core.periods import MONTH
+from openfisca_core.reforms import Reform
+from openfisca_core.variables import Variable
+
+# Import the Entities specifically defined for this tax and benefit system
+from openfisca_country_template.entities import Person
+
+
+class new_tax(Variable):
+    value_type = float
+    entity = Person
+    definition_period = MONTH
+    label = "New tax"
+    reference = "https://law.gov.example/new_tax"  # Always use the most official source
+
+    def formula(person, period, _parameters):
+        """
+        New tax reform.
+
+        Our reform adds a new variable `new_tax` that is calculated based on
+        the current `income_tax`.
+        """
+        return person("income_tax", period) + 100.0
+
+
+class add_new_tax(Reform):
+    def apply(self):
+        """
+        Apply reform.
+
+        A reform always defines an `apply` method that builds the reformed tax
+        and benefit system from the reference one.
+
+        See https://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
+        """
+        self.add_variable(new_tax)

--- a/openfisca_country_template/reforms/add_new_tax.py
+++ b/openfisca_country_template/reforms/add_new_tax.py
@@ -15,6 +15,15 @@ from openfisca_core.variables import Variable
 from openfisca_country_template.entities import Person
 
 
+class has_car(Variable):
+    value_type = bool
+    entity = Person
+    default_value = True
+    definition_period = MONTH
+    label = "The person has a car"
+    reference = "https://law.gov.example/new_tax"  # Always use the most official source
+
+
 class new_tax(Variable):
     value_type = float
     entity = Person
@@ -27,9 +36,12 @@ class new_tax(Variable):
         New tax reform.
 
         Our reform adds a new variable `new_tax` that is calculated based on
-        the current `income_tax`.
+        the current `income_tax`, if the person has a car.
         """
-        return person("income_tax", period) + 100.0
+        income_tax = person("income_tax", period)
+        has_car = person("has_car", period)
+
+        return (income_tax + 100.0) * has_car
 
 
 class add_new_tax(Reform):
@@ -42,4 +54,5 @@ class add_new_tax(Reform):
 
         See https://openfisca.org/doc/coding-the-legislation/reforms.html#writing-a-reform
         """
+        self.add_variable(has_car)
         self.add_variable(new_tax)

--- a/openfisca_country_template/tests/reforms/add_dynamic_variable.yaml
+++ b/openfisca_country_template/tests/reforms/add_dynamic_variable.yaml
@@ -1,0 +1,12 @@
+# Test files describe situations and their expected outcomes
+#
+# We can run this test on our command line using
+# `openfisca-run-test modify_social_security_taxation.yaml`
+#
+# Note the `reforms: ` key in the below YAML blocks.
+
+- name: We will dinamically add new variable "goes_to_school" thanks to a reform
+  reforms: openfisca_country_template.reforms.add_dynamic_variable.add_dynamic_variable
+  period: 2017-01
+  output:
+    goes_to_school: true

--- a/openfisca_country_template/tests/reforms/add_new_tax.yaml
+++ b/openfisca_country_template/tests/reforms/add_new_tax.yaml
@@ -5,11 +5,22 @@
 #
 # Note the `reforms: ` key in the below YAML blocks.
 
-- name: The new tax adds a fixed 100.0 of the country's currency to income tax
+- name: The new tax applies to car-holding people
   reforms: openfisca_country_template.reforms.add_new_tax.add_new_tax
   period: 2017-01
   input:
     salary: 2000
+    has_car: true
   output:
     income_tax: 300
     new_tax: 400
+
+- name: The new tax does not apply otherwise
+  reforms: openfisca_country_template.reforms.add_new_tax.add_new_tax
+  period: 2017-01
+  input:
+    salary: 2000
+    has_car: false
+  output:
+    income_tax: 300
+    new_tax: 0

--- a/openfisca_country_template/tests/reforms/add_new_tax.yaml
+++ b/openfisca_country_template/tests/reforms/add_new_tax.yaml
@@ -1,0 +1,15 @@
+# Test files describe situations and their expected outcomes
+#
+# We can run this test on our command line using
+# `openfisca-run-test modify_social_security_taxation.yaml`
+#
+# Note the `reforms: ` key in the below YAML blocks.
+
+- name: The new tax adds a fixed 100.0 of the country's currency to income tax
+  reforms: openfisca_country_template.reforms.add_new_tax.add_new_tax
+  period: 2017-01
+  input:
+    salary: 2000
+  output:
+    income_tax: 300
+    new_tax: 400

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.9.13",
+    version = "3.10.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
Related to openfisca/openfisca-core#951

* Tax and benefit system evolution.
* Impacted periods: all.
* Impacted areas: `reforms/add_new_tax.py`
* Details:
  - Add a new reform example creating a variable (there was none prior)
  - The example is a new tax that adds a fixed 100.0 of the country's currency to the actual income tax

- - - -

- Add a new feature (for instance adding a variable)