### PR TITLE
Added a new variable and associated params for calculating parenting payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 
 ## 3.12.2 - [#99](https://github.com/openfisca/country-template/pull/99)
 
-* I wanted to have an example to test the new dependencies endpoint in
-  openfisca-core. I wrote the parenting payment variable. There wasn't an
-  example that used group entities/group populations there already, so I wrote
-  this one.
+Added a new variable to demonstrate features and test /dependencies endpoint
+in openfisca-core
 
-  Hopefully it'll be useful for people implementing variables that reference
-  more than one entity as well. :-)
+ * Technical improvement.
+ * Impacted periods: none
+ * Imapcted areas: tests/variables and parameters
 
-  I have updated openfisca-core so the tests pass with the new parameters. 
-  This is the PR: openfisca/openfisca-core#964
+ Details:
+   - Add a new variable called parenting_allowance to show how group
+     entities and single entities can be used together.
+   - This variable calls the household_income variable
 
 ## 3.11.0 - [#90](https://github.com/openfisca/country-template/pull/90)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 3.12.2 - [#99](https://github.com/openfisca/country-template/pull/99)
+
+* I wanted to have an example to test the new dependencies endpoint in
+  openfisca-core. I wrote the parenting payment variable. There wasn't an
+  example that used group entities/group populations there already, so I wrote
+  this one.
+
+  Hopefully it'll be useful for people implementing variables that reference
+  more than one entity as well. :-)
+
+  I have updated openfisca-core so the tests pass with the new parameters. 
+  This is the PR: openfisca/openfisca-core#964
+
 ## 3.11.0 - [#90](https://github.com/openfisca/country-template/pull/90)
 
 * Technical change

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install: deps
 	@# Install OpenFisca-Extension-Template for development.
 	@# `make install` installs the editable version of OpenFisca-France.
 	@# This allows contributors to test as they code.
-	pip install --editable .[dev] --upgrade
+	pip install -e '.[dev]' --upgrade --use-deprecated=legacy-resolver
 
 build: clean deps
 	@# Install OpenFisca-Extension-Template for deployment and publishing.

--- a/openfisca_country_template/parameters/benefits/parenting_allowance.yaml
+++ b/openfisca_country_template/parameters/benefits/parenting_allowance.yaml
@@ -1,0 +1,10 @@
+description: parameters relating to parenting payment
+metadata:
+  reference: https://law.gov.example/parenting_payment/amount
+  unit: currency-EUR
+values:
+  # This parameter is only defined since the 1st of Dec 2015.
+  2015-12-01:
+    value: 600.0
+    metadata:
+      reference: https://law.gov.example/parenting-income/amount/2015-12

--- a/openfisca_country_template/tests/situations/parenting_allowance.yaml
+++ b/openfisca_country_template/tests/situations/parenting_allowance.yaml
@@ -1,0 +1,31 @@
+# You can also use test files to describe complex situations with different entities
+# We can run this test on our command line using `openfisca-run-test tests/situations/income_tax.yaml`
+
+- name: Parenting payment for a two parent household with little income
+  description: Parenting payment relies on the incomes on the parents and ages of the children
+  period: 2020-01
+  absolute_error_margin: 0
+  input:
+    household:
+      parents: [Phil, Saz ]
+      children: [ Caz, Eille, Nimasay ]
+    persons:
+      Phil:
+        birth: 1981-01-15
+        salary:
+         2017-01: 200
+      Saz:
+        birth: 1982-01-15
+        salary:
+         2016: 201
+      Caz:
+        birth: 2010-01-15
+      Eille:
+        birth: 2012-01-15
+      Nimasay:
+        birth: 2018-01-15
+
+  output:
+    household:
+      parenting_allowance:
+        2020-01: 600

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.12.1",
+    version = "3.12.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.11.0",
+    version = "3.12.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers=[


### PR DESCRIPTION
I wanted to have an example to test the new dependencies endpoint in openfisca-core. There wasn't an example that used group entities/group populations there already, so I wrote this one.

Hopefully it'll be useful for people implementing variables that reference more than one entity as well. :-)

I have updated openfisca-core so the tests pass with the new parameters. This is the PR: https://github.com/openfisca/openfisca-core/pull/964

* Tax and benefit system evolution. | Technical improvement. |  Minor change.
* Impacted periods: all.
* Impacted areas: `path/to/file/containing/impacted/variables`
* Details:
  - New feature or new behaviour description
  - Cases for which an error was noticed

- - - -

These changes :

- Impact the OpenFisca-Country-Template public API (for instance renaming or removing a variable)
- Add a new feature (for instance adding a variable)


