### PR TITLE
Fix CHANGELOG versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.13.0 - [#97](https://github.com/openfisca/country-template/pull/97)
+### 3.12.3 - [#97](https://github.com/openfisca/country-template/pull/97)
 
 * Technical improvement.
 * Impacted areas: `**/*`
@@ -20,6 +20,14 @@ in openfisca-core
    - Add a new variable called parenting_allowance to show how group
      entities and single entities can be used together.
    - This variable calls the household_income variable
+
+### 3.12.1 -
+
+> Note: Version `3.12.1` wasn't unpublished by mistake. Please use version `3.12.2` or more recent.
+
+## 3.12.0 -
+
+> Note: Version `3.12.0` wasn't unpublished by mistake. Please use version `3.12.2` or more recent.
 
 ## 3.11.0 - [#90](https://github.com/openfisca/country-template/pull/90)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 3.12.4 - [#103](https://github.com/openfisca/country-template/pull/103)
+
+* Minor change.
+* Details:
+  - Fix CHANGELOG versions:
+    - `3.13.0` was supposed to be `3.12.3`
+    - `3.12.0` and `3.12.1` are unpublished
+
 ### 3.12.3 - [#97](https://github.com/openfisca/country-template/pull/97)
 
 * Technical improvement.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.12.3",
+    version = "3.12.4",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [


### PR DESCRIPTION
* Minor change.
* Details:
  - Fix CHANGELOG versions:
    - `3.13.0` was supposed to be `3.12.3`
    - `3.12.0` and `3.12.1` are unpublished

- - - -

These changes:

- Change non-functional parts of this repository (for instance editing the README)
