### PR TITLE
Forces build reinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 3.12.5 - [#107](https://github.com/openfisca/country-template/pull/107)
+
+* Technical improvement.
+* Details:
+  - Forces the installation of the new build each time `make build` is run
+  - CircleCI tests against the packaged version of this library
+    - When a branch is pushed first time, CircleCI creates a build and caches dependencies
+    - Subsequent pushes do not reinstall the build as it is already in cache
+    - If the code has been modified in between, changes will be ignored, and tests will fail
+
 ### 3.12.4 - [#103](https://github.com/openfisca/country-template/pull/103)
 
 * Minor change.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build: clean deps
 	@# `make build` allows us to be be sure tests are run against the packaged version
 	@# of OpenFisca-Extension-Template, the same we put in the hands of users and reusers.
 	python setup.py bdist_wheel
-	find dist -name "*.whl" -exec pip install --upgrade {}[dev] \;
+	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
 check-syntax-errors:
 	python -m compileall -q .

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.12.4",
+    version = "3.12.5",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [


### PR DESCRIPTION
* Technical improvement.
* Details:
  - Forces the installation of the new build each time `make build` is run
  - CircleCI tests against the packaged version of this library
    - When a branch is pushed first time, CircleCI creates a build and caches dependencies
    - Subsequent pushes do not reinstall the build as it is already in cache
    - If the code has been modified in between, changes will be ignored, and tests will fail

- - - -

These changes :

- Change non-functional parts of this repository (for instance editing the README)