### PR TITLE
Improve packaging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_size = 4
+indent_style = tab
+
+[*.{py, pyi}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{diff,patch}]
+trim_trailing_whitespace = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+default_language_version:
+  python: python3.7
+
+default_stages: [commit, push]
+fail_fast: true
+
+repos:
+  - repo: local
+    hooks:
+      - id: format-style
+        name: format-style
+        entry: make format-style
+        language: system
+
+  - repo: local
+    hooks:
+      - id: clean
+        name: clean
+        entry: make clean
+        language: system
+
+  - repo: local
+    hooks:
+      - id: check-syntax-errors
+        name: check-syntax-errors
+        entry: make check-syntax-errors
+        language: system
+
+  - repo: local
+    hooks:
+      - id: check-safety
+        name: check-safety
+        entry: make check-safety
+        language: system
+
+  - repo: local
+    hooks:
+      - id: check-style
+        name: check-style
+        entry: make check-style
+        language: system
+
+  - repo: local
+    hooks:
+      - id: run-tests
+        name: run-tests
+        entry: make run-tests
+        language: system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Improve `pytest` support for `doctest`
   - Use `pip check` for dependency conflicts
   - Add `pyupgrade` for automatic code formatting
+  - Add `darglint` for improved docstring linting
 
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@
 - Add long description to package distribution
 - Update distribution keywords
 
+# Minor changes
+
+- Relax upper-bound support for OpenFisca-Core
+  - This package and OpenFisca-Core are mutually dependent, which breaks `pip`
+  - The least astonishing is to assume this package to always be compatible with core
+  - This is also easily enforceable thanks to regular dependabot checks that will run in CircleCI
+  - Finally, it is the responsibility of the OpenFisca-Core integrity checks workflow to ensure this package to always be compatible
+    - Every new version of core has to ensure all of the tests included in and distributed by this package pass
+    - Also, every breaking change to OpenFisca-Core has to be phased out to help adapting this package to those changes
+
 ### Major changes
 
 - Drop support for Python < 3.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 4.0.0 - [#111](https://github.com/openfisca/country-template/pull/111)
+
+* Technical improvement.
+* Details:
+  - Add `pyupgrade` for automatic code formatting
+
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)
 
 * Minor change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - Add `pyupgrade` for automatic code formatting
   - Add `darglint` for improved docstring linting
   - Add `.editorconfig` for shared editor configuration
+  - Add `pre-commit` for automatic style checks & formatting
+    - Git hooks are optional, as they may not suit everybody
+    - To enable them, run `pre-commit install`
 
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ### 4.0.0 - [#111](https://github.com/openfisca/country-template/pull/111)
 
-* Technical improvement.
-* Details:
-  - Improve `pytest` support for `doctest`
-  - Use `pip check` for dependency conflicts
-  - Add `pyupgrade` for automatic code formatting
-  - Add `darglint` for improved docstring linting
-  - Add `.editorconfig` for shared editor configuration
-  - Add `pre-commit` for automatic style checks & formatting
-    - Git hooks are optional, as they may not suit everybody
-    - To enable them, run `pre-commit install`
-  - Add long description to package distribution
+### Patch changes
+
+- Improve `pytest` support for `doctest`
+- Use `pip check` for dependency conflicts
+- Add `pyupgrade` for automatic code formatting
+- Add `darglint` for improved docstring linting
+- Add `.editorconfig` for shared editor configuration
+- Add `pre-commit` for automatic style checks & formatting
+  - Git hooks are optional, as they may not suit everybody
+  - To enable them, run `pre-commit install`
+- Add long description to package distribution
+
+### Major changes
+
+- Drop support for Python < 3.7
 
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Git hooks are optional, as they may not suit everybody
   - To enable them, run `pre-commit install`
 - Add long description to package distribution
+- Update distribution keywords
 
 ### Major changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Add `pre-commit` for automatic style checks & formatting
     - Git hooks are optional, as they may not suit everybody
     - To enable them, run `pre-commit install`
+  - Add long description to package distribution
 
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Technical improvement.
 * Details:
+  - Use `pip check` for dependency conflicts
   - Add `pyupgrade` for automatic code formatting
 
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Technical improvement.
 * Details:
+  - Improve `pytest` support for `doctest`
   - Use `pip check` for dependency conflicts
   - Add `pyupgrade` for automatic code formatting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Use `pip check` for dependency conflicts
   - Add `pyupgrade` for automatic code formatting
   - Add `darglint` for improved docstring linting
+  - Add `.editorconfig` for shared editor configuration
 
 ### 3.12.8 - [#105](https://github.com/openfisca/country-template/pull/105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.0.0 - [#111](https://github.com/openfisca/country-template/pull/111)
 
-### Patch changes
+#### Patch changes
 
 - Improve `pytest` support for `doctest`
 - Use `pip check` for dependency conflicts
@@ -15,7 +15,7 @@
 - Add long description to package distribution
 - Update distribution keywords
 
-# Minor changes
+#### Minor changes
 
 - Relax upper-bound support for OpenFisca-Core
   - This package and OpenFisca-Core are mutually dependent, which breaks `pip`
@@ -25,7 +25,7 @@
     - Every new version of core has to ensure all of the tests included in and distributed by this package pass
     - Also, every breaking change to OpenFisca-Core has to be phased out to help adapting this package to those changes
 
-### Major changes
+#### Major changes
 
 - Drop support for Python < 3.7
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ build: clean deps
 check-syntax-errors:
 	python -m compileall -q .
 
+check-safety:
+	pip check
+
 check-style:
 	@# Do not analyse .gitignored files.
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
@@ -38,7 +41,7 @@ format-style:
 	pyupgrade --py37-plus `git ls-files | grep "\.py$$"`
 	autopep8 `git ls-files | grep "\.py$$"`
 
-test: clean check-syntax-errors check-style
+test: clean check-syntax-errors check-safety check-style
 	openfisca test --country-package openfisca_country_template openfisca_country_template/tests
 
 serve-local: build

--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,17 @@ build: clean deps
 check-syntax-errors:
 	python -m compileall -q .
 
-format-style:
-	@# Do not analyse .gitignored files.
-	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	autopep8 `git ls-files | grep "\.py$$"`
-
 check-style:
 	@# Do not analyse .gitignored files.
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	flake8 `git ls-files | grep "\.py$$"`
 	pylint `git ls-files | grep "\.py$$"`
+	flake8 `git ls-files | grep "\.py$$"`
+
+format-style:
+	@# Do not analyse .gitignored files.
+	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
+	pyupgrade --py37-plus `git ls-files | grep "\.py$$"`
+	autopep8 `git ls-files | grep "\.py$$"`
 
 test: clean check-syntax-errors check-style
 	openfisca test --country-package openfisca_country_template openfisca_country_template/tests

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,8 @@
 all: test
+test: clean check-syntax-errors check-safety check-style run-tests
 
 uninstall:
 	pip freeze | grep -v "^-e" | xargs pip uninstall -y
-
-clean:
-	rm -rf build dist
-	find . -name '*.pyc' -exec rm \{\} \;
 
 deps:
 	pip install --upgrade pip twine wheel
@@ -23,6 +20,16 @@ build: clean deps
 	python setup.py bdist_wheel
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
+format-style:
+	@# Do not analyse .gitignored files.
+	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
+	pyupgrade --py37-plus `git ls-files | grep "\.py$$"`
+	autopep8 `git ls-files | grep "\.py$$"`
+
+clean:
+	rm -rf build dist
+	find . -name '*.pyc' -exec rm \{\} \;
+
 check-syntax-errors:
 	python -m compileall -q .
 
@@ -35,13 +42,7 @@ check-style:
 	pylint `git ls-files | grep "\.py$$"`
 	flake8 `git ls-files | grep "\.py$$"`
 
-format-style:
-	@# Do not analyse .gitignored files.
-	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	pyupgrade --py37-plus `git ls-files | grep "\.py$$"`
-	autopep8 `git ls-files | grep "\.py$$"`
-
-test: clean check-syntax-errors check-safety check-style
+run-tests:
 	openfisca test --country-package openfisca_country_template openfisca_country_template/tests
 
 serve-local: build

--- a/openfisca_country_template/situation_examples/__init__.py
+++ b/openfisca_country_template/situation_examples/__init__.py
@@ -10,7 +10,7 @@ DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 def parse(file_name):
     """Load json example situations."""
     file_path = os.path.join(DIR_PATH, file_name)
-    with open(file_path, "r") as file:
+    with open(file_path) as file:
         return json.loads(file.read())
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ disable                   = C0103,C0115,C0301,E0213,E1101,E1102,W0621,W1203
 score                     = no
 
 [tool:pytest]
-addopts                   = --showlocals --exitfirst --doctest-modules
-testpaths                 = openfisca_country_template/tests
-python_files              = **/*.py
+addopts                   = --doctest-modules --exitfirst --showlocals --strict-markers
+doctest_optionflags       = NUMBER NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 filterwarnings            = ignore::DeprecationWarning
+python_files              = **/*.py
+testpaths                 = openfisca_country_template

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,15 +7,17 @@
 ; W503/4:                 We break lines before binary operators (Knuth's style)
 
 [flake8]
+application-import-names  = openfisca_country_template
+application-package-names = openfisca_country_template,openfisca_extension_template
+docstring_style           = google
 hang-closing              = true
 ignore                    = D101,D107,D401,E128,E251,E501,W503
+import-order-style        = appnexus
 in-place                  = true
 inline-quotes             = "
 multiline-quotes          = """
-import-order-style        = appnexus
 no-accept-encodings       = true
-application-import-names  = openfisca_country_template
-application-package-names = openfisca_country_template,openfisca_extension_template
+strictness                = long
 
 ; C0103:                  We (still) snake case variables and reforms
 ; C0115:                  Variables already provide label/description

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 """This file contains your country package's metadata and dependencies."""
 
-from setuptools import find_packages, setup
+import setuptools
 
-setup(
+with open("README.md") as file:
+    readme = file.read()
+
+with open("CHANGELOG.md") as file:
+    changelog = file.read()
+
+setuptools.setup(
     name = "OpenFisca-Country-Template",
     version = "3.12.8",
     author = "OpenFisca Team",
@@ -18,6 +24,8 @@ setup(
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
     description = "OpenFisca tax and benefit system for Country-Template",
+    long_description = "\n".join((readme, changelog)),
+    long_description_content_type="text/markdown",
     keywords = "benefit microsimulation social tax",
     license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url = "https://github.com/openfisca/country-template",
@@ -53,5 +61,5 @@ setup(
             "pyupgrade == 2.14.0",
             ],
         },
-    packages = find_packages(),
+    packages = setuptools.find_packages(),
     )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     description = "OpenFisca tax and benefit system for Country-Template",
     long_description = "\n".join((readme, changelog)),
     long_description_content_type="text/markdown",
-    keywords = "benefit microsimulation social tax",
+    keywords = "microsimulation tax and benefit system rules as code",
     license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     url = "https://github.com/openfisca/country-template",
     include_package_data = True,  # Will read MANIFEST.in

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             "flake8-quotes >= 3.2.0, < 4.0.0",
             "flake8-simplify >= 0.9.0, < 1.0.0",
             "flake8-use-fstring >= 1.1.0, < 2.0.0",
+            "pre-commit == 2.12.1",
             "pylint >= 2.6.0, < 3.0.0",
             "pycodestyle >= 2.6.0, < 3.0.0",
             "pyupgrade == 2.14.0",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     extras_require = {
         "dev": [
             "autopep8 >= 1.5.4, < 2.0.0",
+            "darglint == 1.8.0",
             "flake8 >= 3.8.0, < 4.0.0",
             "flake8-bugbear >= 20.1.0, < 22.0.0",
             "flake8-builtins >= 1.5.0, < 2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
         ],
     python_requires = ">= 3.7",
     install_requires = [
-        "OpenFisca-Core[web-api] >= 35.0.0, < 36.0.0",
+        "OpenFisca-Core[web-api] >= 35.0.0",
         ],
     extras_require = {
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("CHANGELOG.md") as file:
 
 setuptools.setup(
     name = "OpenFisca-Country-Template",
-    version = "3.12.8",
+    version = "4.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "flake8-use-fstring >= 1.1.0, < 2.0.0",
             "pylint >= 2.6.0, < 3.0.0",
             "pycodestyle >= 2.6.0, < 3.0.0",
+            "pyupgrade == 2.14.0",
             ],
         },
     packages = find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
     description = "OpenFisca tax and benefit system for Country-Template",
@@ -36,6 +36,7 @@ setuptools.setup(
             ["CHANGELOG.md", "LICENSE", "README.md"],
             ),
         ],
+    python_requires = ">= 3.7",
     install_requires = [
         "OpenFisca-Core[web-api] >= 35.0.0, < 36.0.0",
         ],


### PR DESCRIPTION
#### Patch changes

- Improve `pytest` support for `doctest`
- Use `pip check` for dependency conflicts
- Add `pyupgrade` for automatic code formatting
- Add `darglint` for improved docstring linting
- Add `.editorconfig` for shared editor configuration
- Add `pre-commit` for automatic style checks & formatting
  - Git hooks are optional, as they may not suit everybody
  - To enable them, run `pre-commit install`
- Add long description to package distribution
- Update distribution keywords

#### Minor changes

- Relax upper-bound support for OpenFisca-Core
  - This package and OpenFisca-Core are mutually dependent, which breaks `pip`
  - The least astonishing is to assume this package to always be compatible with core
  - This is also easily enforceable thanks to regular dependabot checks that will run in CircleCI
  - Finally, it is the responsibility of the OpenFisca-Core integrity checks workflow to ensure this package to always be compatible
    - Every new version of core has to ensure all of the tests included in and distributed by this package pass
    - Also, every breaking change to OpenFisca-Core has to be phased out to help adapting this package to those changes

#### Major changes

- Drop support for Python < 3.7