### PR TITLE
Add tar.gz to pypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 3.13.2 - [#123](https://github.com/openfisca/country-template/pull/123)
+
+* Technical improvement.
+* Details:
+  - Add tar.gz to PyPi to be used by conda to build conda package.
+
 ### 3.13.1 - [#120](https://github.com/openfisca/country-template/pull/120)
 
 * Minor change
@@ -10,7 +16,7 @@
 
 * Technical improvement.
 * Details:
-  - Switch continuous integration pipeline from CircleCI to GitHub Actions 
+  - Switch continuous integration pipeline from CircleCI to GitHub Actions
 
 ### 3.12.10 - [#119](https://github.com/openfisca/country-template/pull/119)
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	find . -name '*.pyc' -exec rm \{\} \;
 
 deps:
-	pip install --upgrade pip twine wheel
+	pip install --upgrade pip build twine
 
 install: deps
 	@# Install OpenFisca-Extension-Template for development.
@@ -20,7 +20,7 @@ build: clean deps
 	@# Install OpenFisca-Extension-Template for deployment and publishing.
 	@# `make build` allows us to be be sure tests are run against the packaged version
 	@# of OpenFisca-Extension-Template, the same we put in the hands of users and reusers.
-	python setup.py bdist_wheel
+	python -m build
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
 check-syntax-errors:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 # Read the contents of our README file for PyPi
 this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+long_description = (this_directory / "README.md").read_text()  # pylint: disable=W1514
 
 setup(
     name = "OpenFisca-Country-Template",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 """This file contains your country package's metadata and dependencies."""
 
-from setuptools import find_packages, setup
 from pathlib import Path
+
+from setuptools import find_packages, setup
 
 # Read the contents of our README file for PyPi
 this_directory = Path(__file__).parent
@@ -24,7 +25,7 @@ setup(
         ],
     description = "OpenFisca tax and benefit system for Country-Template",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     keywords = "benefit microsimulation social tax",
     license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
     license_files = ("LICENSE",),

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 """This file contains your country package's metadata and dependencies."""
 
 from setuptools import find_packages, setup
+from pathlib import Path
+
+# Read the contents of our README file for PyPi
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.13.1",
+    version = "3.13.2",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -18,14 +23,17 @@ setup(
         "Topic :: Scientific/Engineering :: Information Analysis",
         ],
     description = "OpenFisca tax and benefit system for Country-Template",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords = "benefit microsimulation social tax",
     license = "http://www.fsf.org/licensing/licenses/agpl-3.0.html",
+    license_files = ("LICENSE",),
     url = "https://github.com/openfisca/country-template",
     include_package_data = True,  # Will read MANIFEST.in
     data_files = [
         (
             "share/openfisca/openfisca-country-template",
-            ["CHANGELOG.md", "LICENSE", "README.md"],
+            ["CHANGELOG.md", "README.md"],
             ),
         ],
     install_requires = [


### PR DESCRIPTION
* Technical improvement. 
* Details:
  - Add tar.gz source archive to PyPi to allow conda to use it (next PR coming)



These changes change non-functional parts of this repository : CI
