### PR TITLE
Expire deprecated class Bracket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# 4.0.0 - [#127](https://github.com/openfisca/country-template/pull/127)
+
+#### Breaking change
+
+* Technical improvement.
+* Details:
+  - Expire deprecated class `Bracket`.
+  - Functionality is now provided by `ParameterScaleBracket`
+
 ### 3.13.3 - [#122](https://github.com/openfisca/country-template/pull/122)
 
 * Technical improvement. 

--- a/openfisca_country_template/reforms/modify_social_security_taxation.py
+++ b/openfisca_country_template/reforms/modify_social_security_taxation.py
@@ -7,7 +7,7 @@ See https://openfisca.org/doc/key-concepts/reforms.html
 """
 
 # Import from openfisca-core the Python objects used to code the legislation in OpenFisca
-from openfisca_core.parameters import Bracket
+from openfisca_core.parameters import ParameterScaleBracket
 from openfisca_core.reforms import Reform
 
 
@@ -45,7 +45,7 @@ class modify_social_security_taxation(Reform):
         del brackets[0]
 
         # Add a new bracket with a higher tax rate for rich people:
-        new_bracket = Bracket(
+        new_bracket = ParameterScaleBracket(
             "new_bracket",
             data = {
                 "rate": {"2017-01-01": {"value": 0.4}},

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "3.13.3",
+    version = "4.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -38,7 +38,7 @@ setup(
             ),
         ],
     install_requires = [
-        "OpenFisca-Core[web-api] >= 35.0.0, < 36.0.0",
+        "openfisca-core[web-api] >= 37.0.0, < 38.0.0",
         ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
#### Breaking change

* Technical improvement.
* Details:
  - Expire deprecated class `Bracket`.
  - Functionality is now provided by `ParameterScaleBracket`