### PR TITLE
Upgrade OpenAPI spec to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,22 @@
+# Python builds
+
 *.egg-info
 *.pyc
-*~
-.DS_Store
+build
+dist
+.venv
+
+# Editors
+
 .idea
 .project
 .pydevproject
 .python-version
 .settings
 .spyderproject
-.venv
 .vscode
-build
-dist
+
+# OS stuff
+
+.DS_Store
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *~
 .DS_Store
+.idea
 .project
 .pydevproject
 .python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### New features
 
-- Upgrade OpenAPI specification of the API to v3 from Swagger v2.
+- Upgrade Web API specification to OpenAPI v3.
 
 #### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 # 5.0.0 [#128](https://github.com/openfisca/country-template/pull/128)
 
-#### New Features
+#### New features
 
 - Upgrade OpenAPI specification of the API to v3 from Swagger v2.
-- Continuously validate OpenAPI specification.
 
 #### Breaking changes
 
 - Drop support for OpenAPI specification v2 and prior.
-- Users relying on the aforesaid can use [this](https://converter.swagger.io/api/convert?url=OAS2_YAML_OR_JSON_URL) to migrate ([example](https://web.archive.org/web/20221103230822/https://converter.swagger.io/api/convert?url=https://api.demo.openfisca.org/latest/spec)).
+  - Users relying on OpenAPI v2 can use [Swagger Converter](https://converter.swagger.io/api/convert?url=OAS2_YAML_OR_JSON_URL) to migrate ([example](https://web.archive.org/web/20221103230822/https://converter.swagger.io/api/convert?url=https://api.demo.openfisca.org/latest/spec)).
 
 # 4.0.0 - [#127](https://github.com/openfisca/country-template/pull/127)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+# 5.0.0 [#128](https://github.com/openfisca/country-template/pull/128)
+
+#### New Features
+
+- Upgrade OpenAPI specification of the API to v3 from Swagger v2.
+- Continuously validate OpenAPI specification.
+
+#### Breaking changes
+
+- Drop support for OpenAPI specification v2 and prior.
+- Users relying on the aforesaid can use [this](https://converter.swagger.io/api/convert?url=OAS2_YAML_OR_JSON_URL) to migrate ([example](https://web.archive.org/web/20221103230822/https://converter.swagger.io/api/convert?url=https://api.demo.openfisca.org/latest/spec)).
+
 # 4.0.0 - [#127](https://github.com/openfisca/country-template/pull/127)
 
 #### Breaking change

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "4.0.0",
+    version = "5.0.0",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [
@@ -38,7 +38,7 @@ setup(
             ),
         ],
     install_requires = [
-        "openfisca-core[web-api] >= 37.0.0, < 38.0.0",
+        "openfisca-core[web-api] >= 38.0.0, < 39.0.0",
         ],
     extras_require = {
         "dev": [


### PR DESCRIPTION
#### New Features

- Upgrade OpenAPI specification of the API to v3 from Swagger v2.
- Continuously validate OpenAPI specification.

#### Breaking changes

- Drop support for OpenAPI specification v2 and prior.
- Users relying on the aforesaid can use [this](https://converter.swagger.io/api/convert?url=OAS2_YAML_OR_JSON_URL) to migrate ([example](https://web.archive.org/web/20221103230822/https://converter.swagger.io/api/convert?url=https://api.demo.openfisca.org/latest/spec)).

![screenshot](https://user-images.githubusercontent.com/329236/199855222-fcdabe71-0e38-40a1-b598-e12ff04e87e6.png)
