### PR TITLE
Allows country-template to pass check-style makefile command

### DIFF
--- a/openfisca_country_template/__init__.py
+++ b/openfisca_country_template/__init__.py
@@ -11,7 +11,6 @@ See https://openfisca.org/doc/key-concepts/tax_and_benefit_system.html
 import os
 
 from openfisca_core.taxbenefitsystems import TaxBenefitSystem
-
 from openfisca_country_template import entities
 from openfisca_country_template.situation_examples import couple
 

--- a/openfisca_country_template/reforms/add_dynamic_variable.py
+++ b/openfisca_country_template/reforms/add_dynamic_variable.py
@@ -10,7 +10,6 @@ See https://openfisca.org/doc/key-concepts/reforms.html
 from openfisca_core.periods import MONTH
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Person
 

--- a/openfisca_country_template/reforms/add_new_tax.py
+++ b/openfisca_country_template/reforms/add_new_tax.py
@@ -10,7 +10,6 @@ See https://openfisca.org/doc/key-concepts/reforms.html
 from openfisca_core.periods import MONTH
 from openfisca_core.reforms import Reform
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Person
 

--- a/openfisca_country_template/tests/reforms/add_dynamic_variable.yaml
+++ b/openfisca_country_template/tests/reforms/add_dynamic_variable.yaml
@@ -5,7 +5,7 @@
 #
 # Note the `reforms: ` key in the below YAML blocks.
 
-- name: We will dinamically add new variable "goes_to_school" thanks to a reform
+- name: We will dynamically add new variable "goes_to_school" thanks to a reform
   reforms: openfisca_country_template.reforms.add_dynamic_variable.add_dynamic_variable
   period: 2017-01
   output:

--- a/openfisca_country_template/variables/benefits.py
+++ b/openfisca_country_template/variables/benefits.py
@@ -9,7 +9,6 @@ See https://openfisca.org/doc/key-concepts/variables.html
 # Import from openfisca-core the Python objects used to code the legislation in OpenFisca
 from openfisca_core.periods import MONTH
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Household, Person
 

--- a/openfisca_country_template/variables/demographics.py
+++ b/openfisca_country_template/variables/demographics.py
@@ -13,7 +13,6 @@ from datetime import date
 from numpy import where
 from openfisca_core.periods import ETERNITY, MONTH
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Person
 

--- a/openfisca_country_template/variables/housing.py
+++ b/openfisca_country_template/variables/housing.py
@@ -10,7 +10,6 @@ See https://openfisca.org/doc/key-concepts/variables.html
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import MONTH
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Household
 

--- a/openfisca_country_template/variables/income.py
+++ b/openfisca_country_template/variables/income.py
@@ -10,7 +10,6 @@ See https://openfisca.org/doc/key-concepts/variables.html
 from openfisca_core.holders import set_input_divide_by_period
 from openfisca_core.periods import MONTH
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Person
 

--- a/openfisca_country_template/variables/stats.py
+++ b/openfisca_country_template/variables/stats.py
@@ -9,7 +9,6 @@ See https://openfisca.org/doc/key-concepts/variables.html
 # Import from openfisca-core the Python objects used to code the legislation in OpenFisca
 from openfisca_core.periods import MONTH
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Household
 

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -11,7 +11,6 @@ See https://openfisca.org/doc/key-concepts/variables.html
 from numpy import maximum as max_
 from openfisca_core.periods import MONTH, YEAR
 from openfisca_core.variables import Variable
-
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_country_template.entities import Household, Person
 
@@ -76,8 +75,8 @@ class housing_tax(Variable):
         occupancy_status = household("housing_occupancy_status", january)
         HousingOccupancyStatus = occupancy_status.possible_values  # Get the enum associated with the variable
         # To access an enum element, we use the `.` notation.
-        tenant = (occupancy_status == HousingOccupancyStatus.tenant)
-        owner = (occupancy_status == HousingOccupancyStatus.owner)
+        tenant = occupancy_status == HousingOccupancyStatus.tenant
+        owner = occupancy_status == HousingOccupancyStatus.owner
 
         # The tax is applied only if the household owns or rents its main residency
         return (owner + tenant) * tax_amount


### PR DESCRIPTION
Allows country-template to pass check-style makefile command out of the box

* Technical improvement.
* Impacted periods: none.
* Impacted areas: all
* Details:
  - If you follow the make new country template instructions and at the end run `make test` there are style errors. This resolves those errors for that satisfying green tick.

- - - -

These changes:

- Fix or improve an already existing calculation.
- Change non-functional parts of this repository (for instance editing the README)
