### PR TITLE
Ignore .DS_Store in template replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 6.0.1 [#134](https://github.com/openfisca/country-template/pull/134)
+
+* Technical improvement.
+* Impacted areas: template replacement script
+* Details:
+  - Avoid `sed: RE error: illegal byte sequence` error when template contains `.DS_Store` files after GUI navigation in macOS
+
 # 6.0.0 [#129](https://github.com/openfisca/country-template/pull/129)
 
 * Technical improvement.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,7 +31,7 @@ git init
 git add .
 git commit --no-gpg-sign --message 'Initial import from OpenFisca country-template' --author='OpenFisca Bot <bot@openfisca.org>'
 
-all_module_files=`find openfisca_country_template -type f`
+all_module_files=`find openfisca_country_template -type f ! -name "*.DS_Store"`
 
 set -x
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Country-Template",
-    version = "6.0.0",
+    version = "6.0.1",
     author = "OpenFisca Team",
     author_email = "contact@openfisca.org",
     classifiers = [


### PR DESCRIPTION
Fix https://github.com/openfisca/country-template/issues/133

* Technical improvement.
* Impacted areas: template replacement script
* Details:
  - Avoid `sed: RE error: illegal byte sequence` error when template contains `.DS_Store` files after GUI navigation in macOS

- - - -

These changes:

- Change non-functional parts of the country model
