### PR TITLE
Add repository URL to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://example.com/repository"
-Repository = "https://example.com/repository"
+Repository = "https://github.com/openfisca/country-template"
 Documentation = "https://openfisca.org/doc"
 Issues = "https://example.com/repository/issues"
 Changelog = "https://example.com/repository/blob/main/CHANGELOG.md"


### PR DESCRIPTION
Superseded by #139

* Technical improvement
* Details:
  - Add repository URL to pyproject.toml