### PR TITLE
Update references to `setup.py`

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -2,9 +2,7 @@
 
 IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/*"
 
-last_tagged_commit=$(git describe --tags --abbrev=0 --first-parent)  # --first-parent ensures we don't follow tags not published in main through an unlikely intermediary merge commit
-
-if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
+if git diff-index --name-only --exit-code main -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
 then
   echo "No functional changes detected."
   exit 1

--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -2,7 +2,9 @@
 
 IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/*"
 
-if git diff-index --name-only --exit-code main -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
+last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in main through an unlikely intermediary merge commit
+
+if git diff-index --name-only --exit-code $last_tagged_commit -- . `echo " $IGNORE_DIFF_ON" | sed 's/ / :(exclude)/g'`  # Check if any file that has not be listed in IGNORE_DIFF_ON has changed since the last tag was published.
 then
   echo "No functional changes detected."
   exit 1

--- a/.github/is-version-number-acceptable.sh
+++ b/.github/is-version-number-acceptable.sh
@@ -12,14 +12,14 @@ then
     exit 0
 fi
 
-current_version=$(python setup.py --version)
+current_version=$(grep '^version =' pyproject.toml | cut -d '"' -f 2)  # parsing with tomllib is complicated, see https://github.com/python-poetry/poetry/issues/273
 
 if git rev-parse --verify --quiet $current_version
 then
     echo "Version $current_version already exists in commit:"
     git --no-pager log -1 $current_version
     echo
-    echo "Update the version number in setup.py before merging this branch into main."
+    echo "Update the version number in pyproject.toml before merging this branch into main."
     echo "Look at the CONTRIBUTING.md file to learn how the version number should be updated."
     exit 1
 fi

--- a/.github/is-version-number-acceptable.sh
+++ b/.github/is-version-number-acceptable.sh
@@ -14,6 +14,12 @@ fi
 
 current_version=$(grep '^version =' pyproject.toml | cut -d '"' -f 2)  # parsing with tomllib is complicated, see https://github.com/python-poetry/poetry/issues/273
 
+if [[ ! $current_version ]]
+then
+    echo "Error getting current version"
+    exit 1
+fi
+
 if git rev-parse --verify --quiet $current_version
 then
     echo "Version $current_version already exists in commit:"
@@ -21,7 +27,7 @@ then
     echo
     echo "Update the version number in pyproject.toml before merging this branch into main."
     echo "Look at the CONTRIBUTING.md file to learn how the version number should be updated."
-    exit 1
+    exit 2
 fi
 
 if ! $(dirname "$BASH_SOURCE")/has-functional-changes.sh | grep --quiet CHANGELOG.md

--- a/.github/lint-changed-python-files.sh
+++ b/.github/lint-changed-python-files.sh
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 
-if ! changed_files=$(git diff-index --name-only --diff-filter=ACMR --exit-code main -- "*.py")
+last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in main through an unlikely intermediary merge commit
+
+if ! changed_files=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "*.py")
 then
   echo "Linting the following Python files:"
   echo $changed_files

--- a/.github/lint-changed-python-files.sh
+++ b/.github/lint-changed-python-files.sh
@@ -1,11 +1,9 @@
 #! /usr/bin/env bash
 
-last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in main through an unlikely intermediary merge commit
-
-if ! changes=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "*.py")
+if ! changed_files=$(git diff-index --name-only --diff-filter=ACMR --exit-code main -- "*.py")
 then
   echo "Linting the following Python files:"
-  echo $changes
-  flake8 $changes
+  echo $changed_files
+  flake8 $changed_files
 else echo "No changed Python files to lint"
 fi

--- a/.github/lint-changed-yaml-tests.sh
+++ b/.github/lint-changed-yaml-tests.sh
@@ -1,11 +1,9 @@
 #! /usr/bin/env bash
 
-last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in main through an unlikely intermediary merge commit
-
-if ! changes=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "tests/*.yaml")
+if ! changed_files=$(git diff-index --name-only --diff-filter=ACMR --exit-code main -- "tests/*.yaml")
 then
   echo "Linting the following changed YAML tests:"
-  echo $changes
-  yamllint $changes
+  echo $changed_files
+  yamllint $changed_files
 else echo "No changed YAML tests to lint"
 fi

--- a/.github/lint-changed-yaml-tests.sh
+++ b/.github/lint-changed-yaml-tests.sh
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 
-if ! changed_files=$(git diff-index --name-only --diff-filter=ACMR --exit-code main -- "tests/*.yaml")
+last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in main through an unlikely intermediary merge commit
+
+if ! changed_files=$(git diff-index --name-only --diff-filter=ACMR --exit-code $last_tagged_commit -- "tests/*.yaml")
 then
   echo "Linting the following changed YAML tests:"
   echo $changed_files

--- a/.github/publish-git-tag.sh
+++ b/.github/publish-git-tag.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
 
-git tag $(python setup.py --version)
+current_version=$(grep '^version =' pyproject.toml | cut -d '"' -f 2)  # parsing with tomllib is complicated, see https://github.com/python-poetry/poetry/issues/273
+git tag $current_version
 git push --tags  # update the repository version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }} # Cache the entire build Python environment
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }} # Cache the entire build Python environment
           restore-keys: |
-            build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
+            build-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
             build-${{ env.pythonLocation }}-
       - name: Build package
         run: make build
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: dist
-          key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
+          key: release-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
 
   lint-files:
     runs-on: ubuntu-20.04
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
       - run: make check-syntax-errors
       - run: make check-style
       - name: Lint Python files
@@ -73,7 +73,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
       - run: openfisca test --country-package openfisca_country_template openfisca_country_template/tests
 
   test-api:
@@ -90,7 +90,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
       - name: Test the Web API
         run: "${GITHUB_WORKSPACE}/.github/test-api.sh"
 
@@ -148,13 +148,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: build-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
+          key: build-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
       - name: Cache release
         id: restore-release
         uses: actions/cache@v2
         with:
           path: dist
-          key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
+          key: release-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
       - name: Upload a Python package to PyPi
         run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
       - name: Publish a git tag

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -92,7 +92,8 @@ sed -i.template -e "1,${last_changelog_number}d" CHANGELOG.md  # remove country-
 
 echo -e "${PURPLE}*  ${PURPLE}Prepare \033[0m${BLUE}pyproject.toml\033[0m"
 sed -i.template "s|https://github.com/openfisca/country-template|$REPOSITORY_URL|g" pyproject.toml
-sed -i.template "s|:: 5 - Production/Stable|:: 1 - Planning|g" pyproject.toml
+sed -i.template 's|:: 5 - Production/Stable|:: 1 - Planning|g' pyproject.toml
+sed -i.template 's|^version = "[0-9.]*"|version = "0.0.1"|g' pyproject.toml
 sed -i.template "s|repository_folder|$REPOSITORY_FOLDER|g" README.md
 find . -name "*.template" -type f -delete
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -104,7 +104,9 @@ git rm bootstrap.sh > /dev/null 2>&1
 git add .
 git commit --no-gpg-sign --message "$second_commit_message" --author='OpenFisca Bot <bot@openfisca.org>' --quiet
 
-echo -e "${PURPLE}*  ${PURPLE}Second git commit made to 'main' branch: '\033[0m${BLUE}$second_commit_message\033[0m${PURPLE}'\033[0m"
+git tag "0.0.1"
+
+echo -e "${PURPLE}*  ${PURPLE}Second commit and first tag made on 'main' branch: '\033[0m${BLUE}$second_commit_message\033[0m${PURPLE}'\033[0m"
 echo
 
 echo -e "${YELLOW}* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * \033[0m"


### PR DESCRIPTION
Following #139, `setup.py` was replaced by `pyproject.toml`.
However, some workflow files were not updated to reflect that change. While correcting this problem, I identified another one where workflows fail after bootstrapping. This changeset:

- Updates every reference to `setup.py` in the codebase.
- Ensures that there is always at least one tag in the repository after bootstrapping, preventing failure in workflows that expect tags.
- Sets the version number to `0.0.1` upon bootstrapping, matching the value in the CHANGELOG.

To be noted: this is the first PR towards `main`, which currently is aligned with `master`. This pull request should thus, upon merge, trigger the deployment workflow. Since #139 changed the condition for deployment to being on the `main` branch but the main branch was not updated, version 7.0.0 has still not been published.