### PR TITLE
Fix package upload on PyPi

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -133,8 +133,7 @@ jobs:
     needs: [ check-for-functional-changes ]
     if: needs.check-for-functional-changes.outputs.status == 'success'
     env:
-      PYPI_USERNAME: openfisca-bot
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      PYPI_TOKEN_OPENFISCA_BOT: ${{ secrets.PYPI_TOKEN_OPENFISCA_BOT }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -156,6 +155,6 @@ jobs:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}
       - name: Upload a Python package to PyPi
-        run: twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: twine upload dist/* --username __token__ --password $PYPI_TOKEN_OPENFISCA_BOT
       - name: Publish a git tag
         run: "${GITHUB_WORKSPACE}/.github/publish-git-tag.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 7.0.0 [#139](https://github.com/openfisca/country-template/pull/139)
+### [#144](https://github.com/openfisca/country-template/pull/144)
+
+* Bug fix.
+* Details:
+  - Use PyPi token for deployment to fix `HTTPError: 403 Forbidden` on package uplaod
+
+# 7.0.0 [#139](https://github.com/openfisca/country-template/pull/139)
 
 * Technical improvement
 * Major change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### [#144](https://github.com/openfisca/country-template/pull/144)
-
-* Bug fix.
-* Details:
-  - Use PyPi token for deployment to fix `HTTPError: 403 Forbidden` on package upload
-
 # 7.0.0 [#139](https://github.com/openfisca/country-template/pull/139)
 
 * Technical improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Bug fix.
 * Details:
-  - Use PyPi token for deployment to fix `HTTPError: 403 Forbidden` on package uplaod
+  - Use PyPi token for deployment to fix `HTTPError: 403 Forbidden` on package upload
 
 # 7.0.0 [#139](https://github.com/openfisca/country-template/pull/139)
 


### PR DESCRIPTION
* Bug fix. 
* Details:
  - Use PyPi token for deployment to fix `HTTPError: 403 Forbidden` on package upload

- - - -
This PR needs: 
* on PyPi: a PyPi token linked to this repository added to a PyPi account having access to the `OpenFisca Country-Template` project (the token is on the `openfisca-bot` account; we can find it on the [settings page](https://pypi.org/manage/account/))
* on GitHub: a`PYPI_TOKEN_OPENFISCA_BOT` in [this repository secrets](https://github.com/openfisca/country-template/settings/secrets/actions)

> The token and the secret already existed on PyPi and GitHub.
> The syntax has already been tested on other openfisca repositories (like [openfisca-survey-manager](https://github.com/openfisca/openfisca-survey-manager/pull/292/files)).
- - - -

These changes:
- Change non-functional parts of this repository (for instance editing the README)
