### PR TITLE
Update minimal Core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 7.1.1 [#146](https://github.com/openfisca/country-template/pull/146)
+
+* Technical improvement
+* Details:
+  - Update minimal Core dependency to require a version that can parse `pyproject.toml` (see https://github.com/openfisca/openfisca-core/pull/1209)
+  - Use version specifiers compatible with Conda packaging
+
 ## 7.1.0 [#143](https://github.com/openfisca/country-template/pull/143)
 
 * Technical improvement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openfisca-country_template"
-version = "7.1.0"
+version = "7.1.1"
 description = "OpenFisca Rules as Code model for Country-Template."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "openfisca-core[web-api] >=41.0.0, <42.0.0"
+    "openfisca-core[web-api] >=41.4.5, <42.0.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">= 3.9"
+requires-python = ">=3.9"
 dependencies = [
-    "openfisca-core[web-api] >= 41.0.0, < 42.0.0"
+    "openfisca-core[web-api] >=41.0.0, <42.0.0"
 ]
 
 [project.urls]
@@ -28,12 +28,12 @@ Changelog = "https://github.com/openfisca/country-template/blob/main/CHANGELOG.m
 
 [project.optional-dependencies]
 dev = [
-    "autopep8 >= 2.0.4",
-    "flake8 >= 7.0.0",
-    "isort >= 5.13.2",
-    "pylint >= 3.1.0",
-    "pyupgrade >= 3.15.1",
-    "yamllint >= 1.35.1"
+    "autopep8 >=2.0.4",
+    "flake8 >=7.0.0",
+    "isort >=5.13.2",
+    "pylint >=3.1.0",
+    "pyupgrade >=3.15.1",
+    "yamllint >=1.35.1"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
* Technical improvement.
* Details:
  - Update Core dependency to require a version that can parse `pyproject.toml` (see https://github.com/openfisca/openfisca-core/pull/1209).
  - Use version specifiers compatible with Conda according to @benoit-cty in https://github.com/openfisca/openfisca-france/pull/2298/commits/196c469832180b264d339a0c3a32537d5e1461e8