### PR TITLE
chore: update to core 42.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 7.1.5 [#154](https://github.com/openfisca/country-template/pull/154)
+
+* Minor change.
+  - Update OpenFisca-Core to 42.0.0
+
 ### 7.1.4 [#153](https://github.com/openfisca/country-template/pull/153)
 
 * Technical improvement. 
@@ -7,7 +12,7 @@
   - Update README.md references to latest supported python (3.11)
   - Reorder pyproject.toml content to match official example
 
-### 7.1.3 [#152](https://github.com/openfisca/country-template/pull/152)
+### 7.1.3 [#152](https://github.com/openfisca/country-template/pull/147)
 
 * Technical improvement. 
 * Details:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: test
 
 uninstall:
-	pip freeze | grep -v "^-e" | xargs pip uninstall -y
+	pip freeze | grep -v "^-e" | sed "s/@.*//" | xargs pip uninstall -y
 
 clean:
 	rm -rf build dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "openfisca-country_template"
 version = "7.1.4"
 dependencies = [
-    "openfisca-core[web-api] >=41.4.5, <42.0.0"
+    "openfisca-core[web-api] @ https://github.com/openfisca/openfisca-core/archive/fix-mypy-checks-periods.zip"
 ]
 requires-python = ">=3.9"
 authors = []
@@ -80,8 +80,8 @@ known_openfisca = [
     "openfisca_country_template"
 ]
 known_typing = [
-    "mypy*", 
-    "*types*", 
+    "mypy*",
+    "*types*",
     "*typing*"
 ]
 sections = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "openfisca-country_template"
-version = "7.1.4"
+version = "7.1.5"
 dependencies = [
-    "openfisca-core[web-api] @ https://github.com/openfisca/openfisca-core/archive/fix-mypy-checks-periods.zip"
+    "openfisca-core[web-api] >= 42.0.0, <43.0.0",
 ]
 requires-python = ">=3.9"
 authors = []


### PR DESCRIPTION
Depends on openfisca/openfisca-core#1223

* Minor change.
  - Update OpenFisca-Core to 42.0.0

- - - -

These changes:

- Change non-functional parts of this repository (for instance editing the README)
