### PR TITLE
fix: wrongly changed name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 7.1.8 [#159](https://github.com/openfisca/country-template/pull/159)
+
+* Crash fix
+* Impacted areas: `pyproject.toml`
+* Details:
+  - Changed `openfisca-country_template` to `openfisca-country-template` by mistake
+  - This changeset fixes that problem
+
 ### 7.1.7 [#158](https://github.com/openfisca/country-template/pull/158)
 
 * Technical improvement.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build: clean deps
 	@# `make build` allows us to be be sure tests are run against the packaged version
 	@# of OpenFisca-Extension-Template, the same we put in the hands of users and reusers.
 	python -m build
-	pip uninstall --yes openfisca-country-template
+	pip uninstall --yes openfisca-country_template
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
 format:
@@ -30,7 +30,6 @@ format:
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	ruff format `git ls-files | grep "\.py$$"`
 	isort `git ls-files | grep "\.py$$"`
-	pyproject-fmt pyproject.toml
 
 lint:
 	@# Do not analyse .gitignored files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [ "setuptools>=61" ]
 
 [project]
-name = "openfisca-country-template"
+name = "openfisca-country_template"
 version = "7.1.7"
 description = "OpenFisca Rules as Code model for Country-Template."
 readme = "README.md"
@@ -28,7 +28,6 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "isort>=5.13.2,<6",
-    "pyproject-fmt>=2.3.1,<3",
     "ruff>=0.6.9,<1",
     "ruff-lsp>=0.0.57,<1",
     "yamllint>=1.35.1",
@@ -110,7 +109,7 @@ commands_pre = [
         "install",
         "--find-links",
         ".",
-        "openfisca_country_template",
+        "openfisca-country_template",
     ],
 ]
 
@@ -124,7 +123,7 @@ commands_pre = [
         "install",
         "--find-links",
         ".",
-        "openfisca_country_template[dev]",
+        "openfisca-country_template[dev]",
     ],
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "openfisca-country_template"
-version = "7.1.7"
+version = "7.1.8"
 description = "OpenFisca Rules as Code model for Country-Template."
 readme = "README.md"
 keywords = [ "benefit", "microsimulation", "rac", "rules-as-code", "tax" ]


### PR DESCRIPTION
* Crash fix
* Impacted areas: `pyproject.toml`
* Details:
  - Changed `openfisca-country_template` to `openfisca-country-template` by mistake
  - This changeset fixes that problem