### PR TITLE
Include .git in replacing the example repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 8.0.1 [#166](https://github.com/openfisca/country-template/pull/166)
+
+* Technical improvement.
+* Impacted areas: `first-time-setup.sh`
+* Details:
+  - Include .git in replacing the example repo URL
+
 # 8.0.0 [#165](https://github.com/openfisca/country-template/pull/165)
 
 * Tax and benefit system evolution.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Clone this Country Package on your machine:
 git clone https://example.com/repository.git
 cd repository_folder
 pip install --upgrade pip build twine
-pip install --editable .[dev] --upgrade
+pip install --editable ".[dev]" --upgrade
 ```
 
 You can make sure that everything is working by running the provided tests with

--- a/first-time-setup.sh
+++ b/first-time-setup.sh
@@ -36,7 +36,7 @@ do
 	read REPOSITORY_URL
 done
 
-REPOSITORY_FOLDER=$(echo ${REPOSITORY_URL##*/})
+REPOSITORY_FOLDER=$(echo ${REPOSITORY_URL##*/} | sed 's/\.git$//')
 
 cd $(dirname $0)  # support being called from anywhere on the file system
 

--- a/first-time-setup.sh
+++ b/first-time-setup.sh
@@ -88,7 +88,7 @@ echo -e "${PURPLE}*  ${PURPLE}Remove bootstrap instructions\033[0m"
 sed -i.template -e "3,${last_bootstrapping_line_number}d" README.md  # remove instructions lines
 
 echo -e "${PURPLE}*  ${PURPLE}Prepare \033[0m${BLUE}README.MD\033[0m${PURPLE} and \033[0m${BLUE}CONTRIBUTING.md\033[0m"
-sed -i.template "s|https://example.com/repository|$REPOSITORY_URL|g" README.md CONTRIBUTING.md
+sed -i.template "s|https://example.com/repository.git|$REPOSITORY_URL|g" README.md CONTRIBUTING.md
 
 echo -e "${PURPLE}*  ${PURPLE}Prepare \033[0m${BLUE}CHANGELOG.md\033[0m"
 sed -i.template -e "1,${last_changelog_number}d" CHANGELOG.md  # remove country-template CHANGELOG leaving example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "openfisca-country_template"
-version = "8.0.0"
+version = "8.0.1"
 description = "OpenFisca Rules as Code model for Country-Template."
 readme = "README.md"
 keywords = [ "benefit", "microsimulation", "rac", "rules-as-code", "tax" ]


### PR DESCRIPTION
Otherwise the result is repo"_.git.git_" after the script has run