### PR TITLE
chore: normalize pyproject.toml and use Ruff only for lint/format (8.0.2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           python-version: 3.9.12
 
+      - name: Restore built package
+        uses: actions/cache@v4
+        with:
+          path: dist
+          key: release-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
+
       - name: Lint files
         run: tox -r -e lint
 
@@ -39,6 +45,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9.12
+
+      - name: Restore built package
+        uses: actions/cache@v4
+        with:
+          path: dist
+          key: release-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-${{ github.sha }}
 
       - name: Test files
         run: tox -r -e py39

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 8.0.2 (see PR)
+
+* Technical improvement.
+* Impacted areas: `pyproject.toml`, `Makefile`, lint/format tooling.
+* Details:
+  - Normalize `pyproject.toml`: use standard `[project.optional-dependencies]` and `[project.urls]`.
+  - Use Ruff only for lint and format: remove standalone isort; add `[tool.ruff.lint.isort]`.
+  - Makefile: `format` and `lint` targets use only `ruff format` and `ruff check` (and `yamllint`).
+  - Enable import order checks (Ruff isort); apply fixes in `variables/demographics.py` and `variables/taxes.py`.
+
 ### 8.0.1 [#166](https://github.com/openfisca/country-template/pull/166)
 
 * Technical improvement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 8.0.2 (see PR)
+### 8.0.2 [#170](https://github.com/openfisca/country-template/pull/170)
 
 * Technical improvement.
 * Impacted areas: `pyproject.toml`, `Makefile`, lint/format tooling.

--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,16 @@ build: clean deps
 	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
 
 format:
-	@# Do not analyse .gitignored files.
+	@# Do not analyse .gitignored files. Ruff format + ruff check --fix (imports, etc.).
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	ruff format `git ls-files | grep "\.py$$"`
-	isort `git ls-files | grep "\.py$$"`
+	ruff check --fix `git ls-files | grep "\.py$$"`
 
 lint:
 	@# Do not analyse .gitignored files.
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	isort --check `git ls-files | grep "\.py$$"`
 	ruff check `git ls-files | grep "\.py$$"`
+	ruff format --check `git ls-files | grep "\.py$$"`
 	yamllint `git ls-files | grep "\.yaml$$"`
 
 test: clean

--- a/openfisca_country_template/variables/demographics.py
+++ b/openfisca_country_template/variables/demographics.py
@@ -10,7 +10,6 @@ from datetime import date
 # Import from numpy the operations you need to apply on OpenFisca's population vectors
 # Import from openfisca-core the objects used to code the legislation in OpenFisca
 from numpy import where
-
 from openfisca_core.periods import ETERNITY, MONTH
 from openfisca_core.variables import Variable
 

--- a/openfisca_country_template/variables/taxes.py
+++ b/openfisca_country_template/variables/taxes.py
@@ -8,7 +8,6 @@ See https://openfisca.org/doc/key-concepts/variables.html
 # Import from numpy the what you need to apply on OpenFisca's population vectors
 # Import from openfisca-core the objects used to code the legislation in OpenFisca
 from numpy import maximum as max_
-
 from openfisca_core.periods import MONTH, YEAR
 from openfisca_core.variables import Variable
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,20 @@ classifiers = [
 dependencies = [
     "openfisca-core[web-api]>=43",
 ]
-optional-dependencies.dev = [
-    "isort>=5.13.2,<6",
+
+[project.optional-dependencies]
+dev = [
     "ruff>=0.6.9,<1",
     "ruff-lsp>=0.0.57,<1",
     "yamllint>=1.35.1",
 ]
-urls.Changelog = "https://github.com/openfisca/country-template/blob/main/CHANGELOG.md"
-urls.Documentation = "https://openfisca.org/doc"
-urls.Homepage = "https://github.com/openfisca/country-template"
-urls.Issues = "https://github.com/openfisca/country-template/issues"
-urls.Repository = "https://github.com/openfisca/country-template"
+
+[project.urls]
+Changelog = "https://github.com/openfisca/country-template/blob/main/CHANGELOG.md"
+Documentation = "https://openfisca.org/doc"
+Homepage = "https://github.com/openfisca/country-template"
+Issues = "https://github.com/openfisca/country-template/issues"
+Repository = "https://github.com/openfisca/country-template"
 
 [tool.ruff]
 target-version = "py39"
@@ -48,7 +51,6 @@ lint.ignore = [
     "COM812",
     "D101",
     "D104",
-    "I001",
     "ISC001",
     "N801",
     "N805",
@@ -61,30 +63,10 @@ lint.ignore = [
 ]
 lint.pydocstyle.convention = "google"
 
-[tool.isort]
-case_sensitive = true
-combine_as_imports = true
-force_alphabetical_sort_within_sections = false
-group_by_package = true
-honor_noqa = true
-include_trailing_comma = true
-known_first_party = [ "openfisca_country_template" ]
-known_openfisca = [ "openfisca_core", "openfisca_extension_template" ]
-known_typing = [ "*collections.abc*", "*typing*", "*typing_extensions*" ]
-known_types = [ "*types*" ]
-multi_line_output = 3
-profile = "black"
-py_version = 39
-sections = [
-    "FUTURE",
-    "TYPING",
-    "TYPES",
-    "STDLIB",
-    "THIRDPARTY",
-    "OPENFISCA",
-    "FIRSTPARTY",
-    "LOCALFOLDER",
-]
+[tool.ruff.lint.isort]
+known-first-party = [ "openfisca_country_template" ]
+combine-as-imports = true
+force-single-line = false
 
 [tool.pyproject-fmt]
 column_width = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "openfisca-country_template"
-version = "8.0.1"
+version = "8.0.2"
 description = "OpenFisca Rules as Code model for Country-Template."
 readme = "README.md"
 keywords = [ "benefit", "microsimulation", "rac", "rules-as-code", "tax" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ commands_pre = [
         "pip",
         "install",
         "--find-links",
-        ".",
+        "dist",
         "openfisca-country_template",
     ],
 ]
@@ -104,7 +104,7 @@ commands_pre = [
         "pip",
         "install",
         "--find-links",
-        ".",
+        "dist",
         "openfisca-country_template[dev]",
     ],
 ]


### PR DESCRIPTION
* Technical improvement. | ~~Tax and benefit system evolution.~~ | ~~Crash fix.~~ | ~~Minor change.~~
* ~~Impacted periods: all.~~ | ~~until DD/MM/YYYY.~~ | ~~from DD/MM/YYYY.~~
* Impacted areas: `pyproject.toml`, `Makefile`, `openfisca_country_template/variables/demographics.py`, `openfisca_country_template/variables/taxes.py`
* Details:
  - Normalize `pyproject.toml`: use standard `[project.optional-dependencies]` and `[project.urls]`.
  - Use Ruff only for lint and format: remove standalone isort; add `[tool.ruff.lint.isort]` and drop `isort` from dev dependencies.
  - Makefile: `format` and `lint` targets use only `ruff format`, `ruff check`, and `yamllint`.
  - Enable import order checks (remove I001 from Ruff ignore); apply Ruff import fixes in two variable files.

- - - -

These changes:

- ~~Impact the OpenFisca-Country-Template public API (for instance renaming or removing a variable)~~
- ~~Add a new feature (for instance adding a variable)~~
- ~~Fix or improve an already existing calculation.~~
- Change non-functional parts of this repository (pyproject.toml, Makefile, tooling).
