### PR TITLE
feat: demonstrate explicit entity links syntax via Phase 5 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Unreleased (feat/entity-links-demo)
+
+* Technical improvement.
+* Impacted areas: `openfisca_country_template/entities.py`, `pyproject.toml`, `uv.lock`, `openfisca_country_template/tests/test_links_demo.py`.
+* Details:
+  - Pin openfisca-core to PR #1363 (Generic Entity Links) via `[tool.uv.sources]` for testing.
+  - Add entity links demo: mother, employer, employees (Many2One / One2Many); style fixes in entities.py.
+
 ### 8.0.3 [#171](https://github.com/openfisca/country-template/pull/171)
 
 * Technical improvement.

--- a/openfisca_country_template/README_ENTITY_LINKS.md
+++ b/openfisca_country_template/README_ENTITY_LINKS.md
@@ -1,0 +1,58 @@
+# Demonstrating Explicit Entity Links
+
+This branch `feat/entity-links-demo` demonstrates how to implement completely arbitrary entity networks in OpenFisca using the **Phase 5 Country Package API**.
+
+Instead of being restricted to strictly hierarchical standard groups like `Households` containing `Persons`, you can now implement graph-like structures such as:
+1. **Intra-entity links**: Connecting rows inside the exact same population (e.g. `person -> mother_id`).
+2. **Inter-entity networks**: Connecting persons to non-hierarchical unique groups (e.g. `person -> employer_id`).
+
+## What was added in this PR?
+
+### 1. New Link Definitions (`openfisca_country_template/entities.py`)
+
+Using the new `Many2OneLink` and `One2ManyLink` syntax from `openfisca_core`:
+- Introduced a new SingleEntity `Employer`.
+- Linked `Person` to another `Person` via a `mother` link.
+- Linked `Person` to `Employer` via an `employer` link.
+- Linked `Employer` back to `Person` via an `employees` link.
+
+```python
+Person.add_link(Many2OneLink(
+    name="mother",
+    link_field="mother_id",
+    target_entity_key="person"
+))
+
+Employer.add_link(One2ManyLink(
+    name="employees",
+    link_field="employer_id",
+    target_entity_key="person"
+))
+```
+
+### 2. Powerful Dynamic Variables (`openfisca_country_template/variables/links_demo.py`)
+
+Added structural mapping variables holding scalar identifiers (`mother_id`, `employer_id`).
+
+These allow you to write extremely readable code that magically resolves across groups using the new `.get()` and `.sum()` operators!
+
+**Look at how simple querying across arbitrary links has become:**
+```python
+def formula(person, period, parameters):
+    # Fetch exactly the mother's salary vector.
+    # Automatically joins `person -> mother_id -> target.salary`.
+    return person.mother.get("salary", period)
+```
+
+**And executing filtered grouping from one entity to another:**
+```python
+def formula(employer, period, parameters):
+    # Fetch all employees attached to this employer and sum their salaries
+    # You can conditionally apply boolean masks instantly!
+    is_female = employer.simulation.persons("is_female", period)
+    return employer.employees.sum("salary", period, condition=is_female)
+```
+
+### 3. Integrated Example Tests (`openfisca_country_template/tests/test_links_demo.py`)
+
+Shows exactly how you pass data structurally matching these IDs into `SimulationBuilder().build_from_dict()` so that OpenFisca correctly links everything!

--- a/openfisca_country_template/entities.py
+++ b/openfisca_country_template/entities.py
@@ -8,6 +8,8 @@ See https://openfisca.org/doc/key-concepts/person,_entities,_role.html
 
 from openfisca_core.entities import build_entity
 
+from openfisca_core.links import Many2OneLink, One2ManyLink
+
 Household = build_entity(
     key="household",
     plural="households",
@@ -67,4 +69,41 @@ Person = build_entity(
     is_person=True,
 )
 
-entities = [Household, Person]
+Employer = build_entity(
+    key="employer",
+    plural="employers",
+    label="An employer. Example of an alternative non-person single entity.",
+    doc="Demonstrates inter-entity explicit links connecting with Person.",
+    roles=[{"key": "contractor", "plural": "contractors", "label": "Contractor"}],
+)
+
+# ----------------------------------------------------------------------------
+# Declare Explicit Entity Links (Phase 5 of Entity Links Implementation)
+# ----------------------------------------------------------------------------
+
+# 1. Intra-entity Many-to-One Link: A person has one mother (another person).
+Person.add_link(Many2OneLink(
+    name="mother",
+    link_field="mother_id",
+    target_entity_key="person"  # The target of the link is another 'person'
+))
+
+# 2. Inter-entity Many-to-One Link: A person works for one employer.
+Person.add_link(Many2OneLink(
+    name="employer",
+    link_field="employer_id",
+    target_entity_key="employer"
+))
+
+# 3. Inter-entity One-to-Many Link: An employer has many employees (persons).
+Employer.add_link(One2ManyLink(
+    name="employees",
+    link_field="employer_id",  # Defined on the target (person)
+    target_entity_key="person"
+))
+
+# 4. Injected Implicit Links (Automated by OpenFisca core, but noted here for clarity)
+# `person.household` (Many2One) and `household.persons` (One2Many) are automatically
+# injected by OpenFisca during simulation payload resolution.
+
+entities = [Household, Person, Employer]

--- a/openfisca_country_template/entities.py
+++ b/openfisca_country_template/entities.py
@@ -7,7 +7,6 @@ See https://openfisca.org/doc/key-concepts/person,_entities,_role.html
 """
 
 from openfisca_core.entities import build_entity
-
 from openfisca_core.links import Many2OneLink, One2ManyLink
 
 Household = build_entity(
@@ -82,25 +81,29 @@ Employer = build_entity(
 # ----------------------------------------------------------------------------
 
 # 1. Intra-entity Many-to-One Link: A person has one mother (another person).
-Person.add_link(Many2OneLink(
-    name="mother",
-    link_field="mother_id",
-    target_entity_key="person"  # The target of the link is another 'person'
-))
+Person.add_link(
+    Many2OneLink(
+        name="mother",
+        link_field="mother_id",
+        target_entity_key="person",  # The target of the link is another 'person'
+    )
+)
 
 # 2. Inter-entity Many-to-One Link: A person works for one employer.
-Person.add_link(Many2OneLink(
-    name="employer",
-    link_field="employer_id",
-    target_entity_key="employer"
-))
+Person.add_link(
+    Many2OneLink(
+        name="employer", link_field="employer_id", target_entity_key="employer"
+    )
+)
 
 # 3. Inter-entity One-to-Many Link: An employer has many employees (persons).
-Employer.add_link(One2ManyLink(
-    name="employees",
-    link_field="employer_id",  # Defined on the target (person)
-    target_entity_key="person"
-))
+Employer.add_link(
+    One2ManyLink(
+        name="employees",
+        link_field="employer_id",  # Defined on the target (person)
+        target_entity_key="person",
+    )
+)
 
 # 4. Injected Implicit Links (Automated by OpenFisca core, but noted here for clarity)
 # `person.household` (Many2One) and `household.persons` (One2Many) are automatically

--- a/openfisca_country_template/tests/__init__.py
+++ b/openfisca_country_template/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test module for openfisca_country_template."""

--- a/openfisca_country_template/tests/test_links_demo.py
+++ b/openfisca_country_template/tests/test_links_demo.py
@@ -1,7 +1,18 @@
-from openfisca_country_template import CountryTaxBenefitSystem
+"""Test explicit Links mapping in simulation payloads.
+
+This examples test demonstrates how simulation payloads map correctly
+with explicit Links.
+
+This module provides integration tests for the entity linking feature.
+"""
+
 from openfisca_core.simulations import SimulationBuilder
 
+from openfisca_country_template import CountryTaxBenefitSystem
+
+
 def test_links_demo():
+    """Test the correct resolution and aggregation of explicit entity links."""
     tax_benefit_system = CountryTaxBenefitSystem()
 
     # 3 persons:
@@ -9,48 +20,49 @@ def test_links_demo():
     # idx 1: Child (has mother 0) - not female, works for employer 0
     # idx 2: Other (id 2) - female, works for employer 1
 
-    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, {
-        "persons": {
-            "mother": {
-                "salary": {"2024-01": 50000.0},
-                "is_female": {"2024-01": True},
-                "mother_id": {"2024-01": -1},  # Unknown mother
-                "employer_id": {"2024-01": 0}
+    simulation = SimulationBuilder().build_from_dict(
+        tax_benefit_system,
+        {
+            "persons": {
+                "mother": {
+                    "salary": {"2024-01": 50000.0},
+                    "is_female": {"2024-01": True},
+                    "mother_id": {"2024-01": -1},  # Unknown mother
+                    "employer_id": {"2024-01": 0},
+                },
+                "child": {
+                    "salary": {"2024-01": 30000.0},
+                    "is_female": {"2024-01": False},
+                    "mother_id": {"2024-01": 0},  # Mother is index 0
+                    "employer_id": {"2024-01": 0},
+                },
+                "other": {
+                    "salary": {"2024-01": 40000.0},
+                    "is_female": {"2024-01": True},
+                    "mother_id": {"2024-01": -1},
+                    "employer_id": {"2024-01": 1},
+                },
             },
-            "child": {
-                "salary": {"2024-01": 30000.0},
-                "is_female": {"2024-01": False},
-                "mother_id": {"2024-01": 0},  # Mother is index 0
-                "employer_id": {"2024-01": 0}
+            "employers": {
+                "big_corp": {"contractors": ["mother", "child"]},  # id 0
+                "small_biz": {"contractors": ["other"]},  # id 1
             },
-            "other": {
-                "salary": {"2024-01": 40000.0},
-                "is_female": {"2024-01": True},
-                "mother_id": {"2024-01": -1},
-                "employer_id": {"2024-01": 1}
-            }
         },
-        "employers": {
-            "big_corp": {"contractors": ["mother", "child"]},   # id 0
-            "small_biz": {"contractors": ["other"]}   # id 1
-        }
-    })
+    )
 
     # Check Many2OneLink Person -> Mother
     # The child (index 1) should have its mother_salary be 50000.0
     mother_salaries = simulation.calculate("person_mother_salary", "2024-01")
-    assert mother_salaries[1] == 50000.0
+    assert mother_salaries[1] == 50000.0  # noqa: S101
 
     # Check One2ManyLink Employer -> Employees sum aggregation
     # big_corp (id 0) has mother and child, so payroll = 50000 + 30000 = 80000
     # small_biz (id 1) has other, so payroll = 40000
     total_payroll = simulation.calculate("employer_total_payroll", "2024-01")
-    assert total_payroll[0] == 80000.0
-    assert total_payroll[1] == 40000.0
+    assert total_payroll[0] == 80000.0  # noqa: S101
+    assert total_payroll[1] == 40000.0  # noqa: S101
 
     # Check conditional aggregation: just female payroll
-    # big_corp = 50000
-    # small_biz = 40000
     female_payroll = simulation.calculate("employer_female_payroll", "2024-01")
-    assert female_payroll[0] == 50000.0
-    assert female_payroll[1] == 40000.0
+    assert female_payroll[0] == 50000.0  # noqa: S101
+    assert female_payroll[1] == 40000.0  # noqa: S101

--- a/openfisca_country_template/tests/test_links_demo.py
+++ b/openfisca_country_template/tests/test_links_demo.py
@@ -1,0 +1,56 @@
+from openfisca_country_template import CountryTaxBenefitSystem
+from openfisca_core.simulations import SimulationBuilder
+
+def test_links_demo():
+    tax_benefit_system = CountryTaxBenefitSystem()
+
+    # 3 persons:
+    # idx 0: Mother (id 0) - female, works for employer 0
+    # idx 1: Child (has mother 0) - not female, works for employer 0
+    # idx 2: Other (id 2) - female, works for employer 1
+
+    simulation = SimulationBuilder().build_from_dict(tax_benefit_system, {
+        "persons": {
+            "mother": {
+                "salary": {"2024-01": 50000.0},
+                "is_female": {"2024-01": True},
+                "mother_id": {"2024-01": -1},  # Unknown mother
+                "employer_id": {"2024-01": 0}
+            },
+            "child": {
+                "salary": {"2024-01": 30000.0},
+                "is_female": {"2024-01": False},
+                "mother_id": {"2024-01": 0},  # Mother is index 0
+                "employer_id": {"2024-01": 0}
+            },
+            "other": {
+                "salary": {"2024-01": 40000.0},
+                "is_female": {"2024-01": True},
+                "mother_id": {"2024-01": -1},
+                "employer_id": {"2024-01": 1}
+            }
+        },
+        "employers": {
+            "big_corp": {"contractors": ["mother", "child"]},   # id 0
+            "small_biz": {"contractors": ["other"]}   # id 1
+        }
+    })
+
+    # Check Many2OneLink Person -> Mother
+    # The child (index 1) should have its mother_salary be 50000.0
+    mother_salaries = simulation.calculate("person_mother_salary", "2024-01")
+    assert mother_salaries[1] == 50000.0
+
+    # Check One2ManyLink Employer -> Employees sum aggregation
+    # big_corp (id 0) has mother and child, so payroll = 50000 + 30000 = 80000
+    # small_biz (id 1) has other, so payroll = 40000
+    total_payroll = simulation.calculate("employer_total_payroll", "2024-01")
+    assert total_payroll[0] == 80000.0
+    assert total_payroll[1] == 40000.0
+
+    # Check conditional aggregation: just female payroll
+    # big_corp = 50000
+    # small_biz = 40000
+    female_payroll = simulation.calculate("employer_female_payroll", "2024-01")
+    assert female_payroll[0] == 50000.0
+    assert female_payroll[1] == 40000.0

--- a/openfisca_country_template/variables/links_demo.py
+++ b/openfisca_country_template/variables/links_demo.py
@@ -1,0 +1,71 @@
+"""This module demonstrates the new generic Entity Link syntax."""
+
+from openfisca_core.periods import ETERNITY
+from openfisca_core.variables import Variable
+
+from openfisca_country_template.entities import Employer, Person
+
+
+# ----------------------------------------------------------------------------
+# 1. Structural Variables (Holding IDs)
+# ----------------------------------------------------------------------------
+class mother_id(Variable):
+    value_type = int
+    entity = Person
+    definition_period = ETERNITY
+    default_value = -1
+    label = "ID of the person's mother (Intra-entity link)"
+
+
+class employer_id(Variable):
+    value_type = int
+    entity = Person
+    definition_period = ETERNITY
+    default_value = -1
+    label = "ID of the person's employer (Inter-entity link)"
+
+
+# ----------------------------------------------------------------------------
+# 2. Functional Variables Using Links
+# ----------------------------------------------------------------------------
+class person_mother_salary(Variable):
+    value_type = float
+    entity = Person
+    definition_period = ETERNITY
+    label = "Salary extracted directly from the person's mother"
+
+    def formula(person, period, parameters):
+        # Fetches `salary` dynamically by resolving `person.mother_id`
+        # and retrieving the corresponding salary on the target person instance.
+        return person.mother.get("salary", period)
+
+
+class employer_total_payroll(Variable):
+    value_type = float
+    entity = Employer
+    definition_period = ETERNITY
+    label = "Total salary paid by an employer to all its employees"
+
+    def formula(employer, period, parameters):
+        # Uses explicit One2ManyLink. Resolves all persons holding this employer's ID
+        # and aggregates their dynamically retrieved salaries.
+        return employer.employees.sum("salary", period)
+
+
+class employer_female_payroll(Variable):
+    value_type = float
+    entity = Employer
+    definition_period = ETERNITY
+    label = "Total salary paid by an employer, but conditionally only to females"
+
+    def formula(employer, period, parameters):
+        # Similar logic: we can filter One2ManyLink aggregations natively via explicit conditions.
+        is_female = employer.simulation.persons("is_female", period)
+        return employer.employees.sum("salary", period, condition=is_female)
+
+class is_female(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = ETERNITY
+    label = "Is the person a female?"
+    default_value = False

--- a/openfisca_country_template/variables/links_demo.py
+++ b/openfisca_country_template/variables/links_demo.py
@@ -34,7 +34,8 @@ class person_mother_salary(Variable):
     definition_period = ETERNITY
     label = "Salary extracted directly from the person's mother"
 
-    def formula(person, period, parameters):
+    def formula(person, period, _parameters):
+        """Fetch mother's salary."""
         # Fetches `salary` dynamically by resolving `person.mother_id`
         # and retrieving the corresponding salary on the target person instance.
         return person.mother.get("salary", period)
@@ -46,7 +47,8 @@ class employer_total_payroll(Variable):
     definition_period = ETERNITY
     label = "Total salary paid by an employer to all its employees"
 
-    def formula(employer, period, parameters):
+    def formula(employer, period, _parameters):
+        """Return total employee salaries."""
         # Uses explicit One2ManyLink. Resolves all persons holding this employer's ID
         # and aggregates their dynamically retrieved salaries.
         return employer.employees.sum("salary", period)
@@ -58,10 +60,13 @@ class employer_female_payroll(Variable):
     definition_period = ETERNITY
     label = "Total salary paid by an employer, but conditionally only to females"
 
-    def formula(employer, period, parameters):
-        # Similar logic: we can filter One2ManyLink aggregations natively via explicit conditions.
+    def formula(employer, period, _parameters):
+        """Return total employee salaries for females."""
+        # Similar logic: we can filter One2ManyLink aggregations natively
+        # via explicit conditions.
         is_female = employer.simulation.persons("is_female", period)
         return employer.employees.sum("salary", period, condition=is_female)
+
 
 class is_female(Variable):
     value_type = bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "openfisca-core[web-api]>=43",
 ]
 
+[tool.uv.sources]
+openfisca-core = { git = "https://github.com/openfisca/openfisca-core.git", branch = "feat/entity-links" }
+
 [project.optional-dependencies]
 dev = [
     "ruff>=0.6.9,<1",

--- a/uv.lock
+++ b/uv.lock
@@ -1003,8 +1003,8 @@ wheels = [
 
 [[package]]
 name = "openfisca-core"
-version = "44.2.2"
-source = { registry = "https://pypi.org/simple" }
+version = "44.3.0"
+source = { git = "https://github.com/openfisca/openfisca-core.git?branch=feat%2Fentity-links#5b49db2a09c6a811870c7aa3ad6a036e21e20cd7" }
 dependencies = [
     { name = "dpath" },
     { name = "numexpr", version = "2.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1019,10 +1019,6 @@ dependencies = [
     { name = "strenum" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/4c/128b54954a5d96615a30023fd4ea458379c6f9c607d10e8e9cf4abb61fe3/openfisca_core-44.2.2.tar.gz", hash = "sha256:d5d4d9c16dbb669d3736c5fd2117ea8950714a52d78216535c680098febac7d5", size = 208072 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/02/0a31be34cc7c697599c9e538988afee62624344616b92d68240c916dce91/openfisca_core-44.2.2-py3-none-any.whl", hash = "sha256:b55d293d0e2a4840f6db5f33450c588f08753abb189cbfa6ff9c5e2a28ed7402", size = 268685 },
-]
 
 [package.optional-dependencies]
 web-api = [
@@ -1034,7 +1030,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-country-template"
-version = "8.0.2"
+version = "8.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },
@@ -1059,7 +1055,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "openfisca-core", extras = ["web-api"], specifier = ">=43" },
+    { name = "openfisca-core", extras = ["web-api"], git = "https://github.com/openfisca/openfisca-core.git?branch=feat%2Fentity-links" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.9,<1" },
     { name = "ruff-lsp", marker = "extra == 'dev'", specifier = ">=0.0.57,<1" },
     { name = "yamllint", marker = "extra == 'dev'", specifier = ">=1.35.1" },


### PR DESCRIPTION
# Demonstrating Explicit Entity Links

This branch `feat/entity-links-demo` demonstrates how to implement completely arbitrary entity networks in OpenFisca using the **Phase 5 Country Package API**.

Instead of being restricted to strictly hierarchical standard groups like `Households` containing `Persons`, you can now implement graph-like structures such as:
1. **Intra-entity links**: Connecting rows inside the exact same population (e.g. `person -> mother_id`).
2. **Inter-entity networks**: Connecting persons to non-hierarchical unique groups (e.g. `person -> employer_id`).

## What was added in this PR?

### 1. New Link Definitions (`openfisca_country_template/entities.py`)

Using the new `Many2OneLink` and `One2ManyLink` syntax from `openfisca_core`:
- Introduced a new SingleEntity `Employer`.
- Linked `Person` to another `Person` via a `mother` link.
- Linked `Person` to `Employer` via an `employer` link.
- Linked `Employer` back to `Person` via an `employees` link.

```python
Person.add_link(Many2OneLink(
    name="mother",
    link_field="mother_id",
    target_entity_key="person"
))

Employer.add_link(One2ManyLink(
    name="employees",
    link_field="employer_id",
    target_entity_key="person"
))
```

### 2. Powerful Dynamic Variables (`openfisca_country_template/variables/links_demo.py`)

Added structural mapping variables holding scalar identifiers (`mother_id`, `employer_id`).

These allow you to write extremely readable code that magically resolves across groups using the new `.get()` and `.sum()` operators!

**Look at how simple querying across arbitrary links has become:**
```python
def formula(person, period, parameters):
    # Fetch exactly the mother's salary vector.
    # Automatically joins `person -> mother_id -> target.salary`.
    return person.mother.get("salary", period)
```

**And executing filtered grouping from one entity to another:**
```python
def formula(employer, period, parameters):
    # Fetch all employees attached to this employer and sum their salaries
    # You can conditionally apply boolean masks instantly!
    is_female = employer.simulation.persons("is_female", period)
    return employer.employees.sum("salary", period, condition=is_female)
```

### 3. Integrated Example Tests (`openfisca_country_template/tests/test_links_demo.py`)

Shows exactly how you pass data structurally matching these IDs into `SimulationBuilder().build_from_dict()` so that OpenFisca correctly links everything!
